### PR TITLE
Fix incorrect admonition types

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -159,7 +159,7 @@ def get_pet(pet_id):
     return {'message': 'Pet'}
 ```
 
-!!! tips "Use exception classes from Werkzeug"
+!!! tip "Use exception classes from Werkzeug"
 
     If you didn't set the `json_errors` to `False` when creating `app` instance,
     APIFlask will catch all the Werkzeug exceptions, including the one you raised

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -120,7 +120,7 @@ app = APIFlask(__name__, spec_path='/spec')
 
 Then the spec will be available at http://localhost:5000/spec.
 
-!!! tips
+!!! tip
 
     You can configure the MIME type of the spec response with the configuration
     variable `YAML_SPEC_MIMETYPE` and `JSON_SPEC_MIMETYPE`, see details in the
@@ -266,7 +266,7 @@ app.config['SYNC_LOCAL_SPEC'] = True
 app.config['LOCAL_SPEC_PATH'] = Path(app.root_path) / 'openapi.json'
 ```
 
-!!! tips
+!!! tip
 
     You can also use
     [`app.instance_path`](https://flask.palletsprojects.com/config/#instance-folders){target=_blank},
@@ -387,7 +387,7 @@ app.config['TAGS'] = [
 ]
 ```
 
-!!! tips
+!!! tip
 
     The `app.tags` attribute is equals to the configuration variable `TAGS`, so you
     can also use:
@@ -592,7 +592,7 @@ Normally, you only need to set the following fields manually with the `metadata`
 See details in
 *[OpenAPI XML object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#xmlObject)*.
 
-!!! tips
+!!! tip
 
     If the schema class' name ends with `Schema`, then it will be stripped in the spec.
 
@@ -836,7 +836,7 @@ from apiflask import APIFlask
 app = APIFlask(__name__, enable_openapi=False)
 ```
 
-!!! tips
+!!! tip
 
     If you only need to disable the API documentation, see
     *[Disable the API documentations globally](/api-docs/#disable-the-api-documentations-globally)*.
@@ -853,7 +853,7 @@ from apiflask import APIBlueprint
 bp = APIBlueprint(__name__, 'foo', enable_openapi=False)
 ```
 
-!!! tips
+!!! tip
 
     APIFlask will skip a blueprint if the blueprint is created by other Flask
     extensions.

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -594,7 +594,7 @@ See details in
 
 !!! tips
 
-    If the schema class' name ends with `Schema`, then it will be striped in the spec.
+    If the schema class' name ends with `Schema`, then it will be stripped in the spec.
 
 
 ### Response and request example

--- a/docs/request.md
+++ b/docs/request.md
@@ -61,7 +61,7 @@ def hello(query, data):
     pass
 ```
 
-!!! tips
+!!! tip
 
     The argument name (`query, data`) in the view function is defined by you, you can use anything you like.
 
@@ -75,7 +75,7 @@ def get_article(category, article_id, query, data):
     pass
 ```
 
-!!! tips
+!!! tip
 
     Notice the argument name for URL variables (`category, article_id`) must match the variable name.
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -43,7 +43,7 @@ And there are two decorators to register a validation method:
 - `validates(field_name)`: to register a method to validate a specified field
 - `validates_schema`: to register a method to validate the whole schema
 
-!!! tips
+!!! tip
 
     When using the `validates_schema`, notice the `skip_on_field_errors` is set to `True` as default:
     > If skip_on_field_errors=True, this validation method will be skipped whenever validation errors
@@ -161,7 +161,7 @@ API documentation: <https://apiflask.com/api/fields/#apiflask.fields.File>
 
 - `File`
 
-!!! tips
+!!! tip
 
     If the existing fields don't fit your needs, you can also create
     [custom fields](https://marshmallow.readthedocs.io/en/stable/custom_fields.html).
@@ -211,7 +211,7 @@ class PetInSchema(Schema):
     category = String(required=True, validate=[OneOf(['dog', 'cat']), Length(0, 10)])
 ```
 
-!!! tips
+!!! tip
 
     If the existing validators don't fit your needs, you can also create
     [custom validators](https://marshmallow.readthedocs.io/en/stable/quickstart.html#validation).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -839,7 +839,7 @@ def create_pet(data):
     return pet, {'FOO': 'bar'}
 ```
 
-!!! tips
+!!! tip
 
     Be sure to always set the `status_code` argument in `@app.output` when you want
     to use a non-200 status code. If there is a mismatch, the `status_code`
@@ -1032,7 +1032,7 @@ class Pet(MethodView):
     # ...
 ```
 
-!!! tips
+!!! tip
 
     If the `endpoint` argument isn't provided, the class name will be used as
     endpoint. You don't need to pass a `methods` argument, since Flask will handle


### PR DESCRIPTION
<!--
For features and bug fixes, before opening a PR, please open an issue describing
the bug or feature the PR will address. You can skip this step if it's a typo fix.

Replace this comment with a description of the change. Describe how it
addresses the linked issue.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fix typo in openapi.md

<!--
If needed, ensure each step in the checklist below is complete. If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the `docs` folder and in code docstring.
- [ ] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [ ] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [ ] Run `pytest` and `tox`, no tests failed.
