### PR TITLE
Fix typo in docs/request-handling

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -8,7 +8,7 @@ The error handling in APIFlask is based on the following basic concepts:
 - Use `APIFlask.abort()` function or raise `HTTPError` classes to generate an error response.
 - Use `app.error_processor` (`app` is an instance of `apiflask.APIFlask`) to register a
   custom error response processor.
-- Use `auth.error_processor` (`app` is an instance of `apiflask.HTTPBasicAuth` or
+- Use `auth.error_processor` (`auth` is an instance of `apiflask.HTTPBasicAuth` or
   `apiflask.HTTPTokenAuth`) to register a custom auth error response processor.
 - Subclass `HTTPError` to create custom error classes for your errors.
 


### PR DESCRIPTION
Instance of apiflask.HTTPBasicAuth should be "auth"

<!--
For features and bug fixes, before opening a PR, please open an issue describing
the bug or feature the PR will address. You can skip this step if it's a typo fix.

Replace this comment with a description of the change. Describe how it
addresses the linked issue.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #<issue number>

<!--
If needed, ensure each step in the checklist below is complete. If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the `docs` folder and in code docstring.
- [ ] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [ ] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [ ] Run `pytest` and `tox`, no tests failed.
