### PR TITLE
Fix CLI entry point setup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,8 +19,11 @@ Released: -
     - `RAPIDOC_CONFIG`
     - `RAPIPDF_JS`
     - `RAPIPDF_CONFIG`
+- Fix CLI entry point setup to prevent overwriting `flask`
+  ([issue #312][issue_312])
 
 [pr_308]: https://github.com/apiflask/apiflask/pull/308
+[issue_312]: https://github.com/apiflask/apiflask/issues/312
 
 
 ## Version 1.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,8 @@ python_requires = >= 3.7
 where = src
 
 [options.entry_points]
+console_scripts =
+    apiflask = flask.cli:main
 flask.commands =
     spec = apiflask.commands:spec_command
 

--- a/src/apiflask/commands.py
+++ b/src/apiflask/commands.py
@@ -5,7 +5,7 @@ from flask import current_app
 from flask.cli import with_appcontext
 
 
-@click.command('spec')
+@click.command('spec', short_help='Show the OpenAPI spec.')
 @click.option(
     '--format',
     '-f',
@@ -26,11 +26,11 @@ from flask.cli import with_appcontext
 )
 @with_appcontext
 def spec_command(format, output, indent):
-    """The command (`flask spec`) to output the OpenAPI spec to stdout or a file.
+    """Output the OpenAPI spec to stdout or a file.
 
-    Execute `flask spec --help` to see the usage.
+    Check out the docs for the detailed usage:
 
-    *Version added: 0.7.0*
+    https://apiflask.com/openapi/#the-flask-spec-command
     """
     spec_format = format or current_app.config['SPEC_FORMAT']
     spec = current_app._get_spec(spec_format)


### PR DESCRIPTION
- Add an `apiflask` console script to prevent overwriting `flask`.
- Add a short help text for the `flask spec` command.

fixes #312
