### PR TITLE
Simplify the async-related tests

### DIFF
--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -104,7 +104,7 @@ def test_output_on_async_view(app, client):
 
 
 def test_async_doc_input_and_output_decorator(app, client):
-    
+
     @app.post('/')
     @app.doc(summary='Test Root Endpoint')
     @app.input(FooSchema)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -12,7 +12,6 @@ def skip_async_test(app):
 
 
 def test_async_view(app, client):
-    
     @app.get('/')
     async def index():
         return {'message': 'hello'}
@@ -23,7 +22,6 @@ def test_async_view(app, client):
 
 
 def test_async_error_processor(app, client):
-    
     @app.error_processor
     async def custom_error_processor(e):
         return {'foo': 'test'}, e.status_code, e.headers
@@ -34,7 +32,6 @@ def test_async_error_processor(app, client):
 
 
 def test_async_spec_processor(app, client):
-    
     @app.spec_processor
     async def update_spec(spec):
         spec['info']['title'] = 'Updated Title'
@@ -48,7 +45,6 @@ def test_async_spec_processor(app, client):
 
 def test_auth_required_on_async_view(app, client):
     auth = HTTPTokenAuth()
-
     @app.get('/')
     @app.auth_required(auth)
     async def index():
@@ -59,7 +55,6 @@ def test_auth_required_on_async_view(app, client):
 
 
 def test_doc_on_async_view(app, client):
-    
     @app.get('/')
     @app.doc(summary='Test Root Endpoint')
     async def index():
@@ -71,7 +66,6 @@ def test_doc_on_async_view(app, client):
 
 
 def test_input_on_async_view(app, client):
-    
     @app.post('/')
     @app.input(FooSchema)
     async def index(data):
@@ -84,7 +78,6 @@ def test_input_on_async_view(app, client):
 
 
 def test_output_on_async_view(app, client):
-    
     @app.get('/foo')
     @app.output(FooSchema)
     async def foo():
@@ -104,7 +97,6 @@ def test_output_on_async_view(app, client):
 
 
 def test_async_doc_input_and_output_decorator(app, client):
-    
     @app.post('/')
     @app.doc(summary='Test Root Endpoint')
     @app.input(FooSchema)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -12,6 +12,7 @@ def skip_async_test(app):
 
 
 def test_async_view(app, client):
+
     @app.get('/')
     async def index():
         return {'message': 'hello'}
@@ -22,6 +23,7 @@ def test_async_view(app, client):
 
 
 def test_async_error_processor(app, client):
+
     @app.error_processor
     async def custom_error_processor(e):
         return {'foo': 'test'}, e.status_code, e.headers
@@ -32,6 +34,7 @@ def test_async_error_processor(app, client):
 
 
 def test_async_spec_processor(app, client):
+
     @app.spec_processor
     async def update_spec(spec):
         spec['info']['title'] = 'Updated Title'
@@ -45,6 +48,7 @@ def test_async_spec_processor(app, client):
 
 def test_auth_required_on_async_view(app, client):
     auth = HTTPTokenAuth()
+
     @app.get('/')
     @app.auth_required(auth)
     async def index():
@@ -55,6 +59,7 @@ def test_auth_required_on_async_view(app, client):
 
 
 def test_doc_on_async_view(app, client):
+
     @app.get('/')
     @app.doc(summary='Test Root Endpoint')
     async def index():
@@ -66,6 +71,7 @@ def test_doc_on_async_view(app, client):
 
 
 def test_input_on_async_view(app, client):
+
     @app.post('/')
     @app.input(FooSchema)
     async def index(data):
@@ -78,6 +84,7 @@ def test_input_on_async_view(app, client):
 
 
 def test_output_on_async_view(app, client):
+
     @app.get('/foo')
     @app.output(FooSchema)
     async def foo():
@@ -97,6 +104,7 @@ def test_output_on_async_view(app, client):
 
 
 def test_async_doc_input_and_output_decorator(app, client):
+    
     @app.post('/')
     @app.doc(summary='Test Root Endpoint')
     @app.input(FooSchema)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -4,14 +4,15 @@ from openapi_spec_validator import validate_spec
 from .schemas import FooSchema
 from apiflask import HTTPTokenAuth
 
-
-def skip_flask1(app):
+@pytest.fixture(autouse=True)
+def skip_async_test(app):
     if not hasattr(app, 'ensure_sync'):
         pytest.skip('This test requires Flask 2.0 or higher')
 
 
+
 def test_async_view(app, client):
-    skip_flask1(app)
+    skip_async_test(app)
 
     @app.get('/')
     async def index():
@@ -23,7 +24,7 @@ def test_async_view(app, client):
 
 
 def test_async_error_processor(app, client):
-    skip_flask1(app)
+    skip_async_test(app)
 
     @app.error_processor
     async def custom_error_processor(e):
@@ -35,7 +36,7 @@ def test_async_error_processor(app, client):
 
 
 def test_async_spec_processor(app, client):
-    skip_flask1(app)
+    skip_async_test(app)
 
     @app.spec_processor
     async def update_spec(spec):
@@ -49,7 +50,7 @@ def test_async_spec_processor(app, client):
 
 
 def test_auth_required_on_async_view(app, client):
-    skip_flask1(app)
+    skip_async_test(app)
     auth = HTTPTokenAuth()
 
     @app.get('/')
@@ -62,7 +63,7 @@ def test_auth_required_on_async_view(app, client):
 
 
 def test_doc_on_async_view(app, client):
-    skip_flask1(app)
+    skip_async_test(app)
 
     @app.get('/')
     @app.doc(summary='Test Root Endpoint')
@@ -75,7 +76,7 @@ def test_doc_on_async_view(app, client):
 
 
 def test_input_on_async_view(app, client):
-    skip_flask1(app)
+    skip_async_test(app)
 
     @app.post('/')
     @app.input(FooSchema)
@@ -89,7 +90,7 @@ def test_input_on_async_view(app, client):
 
 
 def test_output_on_async_view(app, client):
-    skip_flask1(app)
+    skip_async_test(app)
 
     @app.get('/foo')
     @app.output(FooSchema)
@@ -110,7 +111,7 @@ def test_output_on_async_view(app, client):
 
 
 def test_async_doc_input_and_output_decorator(app, client):
-    skip_flask1(app)
+    skip_async_test(app)
 
     @app.post('/')
     @app.doc(summary='Test Root Endpoint')

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -4,15 +4,15 @@ from openapi_spec_validator import validate_spec
 from .schemas import FooSchema
 from apiflask import HTTPTokenAuth
 
+
 @pytest.fixture(autouse=True)
 def skip_async_test(app):
     if not hasattr(app, 'ensure_sync'):
         pytest.skip('This test requires Flask 2.0 or higher')
 
 
-
 def test_async_view(app, client):
-    skip_async_test(app)
+    #skip_flask1(app)
 
     @app.get('/')
     async def index():
@@ -24,7 +24,7 @@ def test_async_view(app, client):
 
 
 def test_async_error_processor(app, client):
-    skip_async_test(app)
+    #skip_flask1(app)
 
     @app.error_processor
     async def custom_error_processor(e):
@@ -36,7 +36,7 @@ def test_async_error_processor(app, client):
 
 
 def test_async_spec_processor(app, client):
-    skip_async_test(app)
+    #skip_flask1(app)
 
     @app.spec_processor
     async def update_spec(spec):
@@ -50,7 +50,7 @@ def test_async_spec_processor(app, client):
 
 
 def test_auth_required_on_async_view(app, client):
-    skip_async_test(app)
+    #skip_flask1(app)
     auth = HTTPTokenAuth()
 
     @app.get('/')
@@ -63,7 +63,7 @@ def test_auth_required_on_async_view(app, client):
 
 
 def test_doc_on_async_view(app, client):
-    skip_async_test(app)
+    #skip_flask1(app)
 
     @app.get('/')
     @app.doc(summary='Test Root Endpoint')
@@ -76,7 +76,7 @@ def test_doc_on_async_view(app, client):
 
 
 def test_input_on_async_view(app, client):
-    skip_async_test(app)
+    #skip_flask1(app)
 
     @app.post('/')
     @app.input(FooSchema)
@@ -90,7 +90,7 @@ def test_input_on_async_view(app, client):
 
 
 def test_output_on_async_view(app, client):
-    skip_async_test(app)
+    #skip_flask1(app)
 
     @app.get('/foo')
     @app.output(FooSchema)
@@ -111,7 +111,7 @@ def test_output_on_async_view(app, client):
 
 
 def test_async_doc_input_and_output_decorator(app, client):
-    skip_async_test(app)
+    #skip_flask1(app)
 
     @app.post('/')
     @app.doc(summary='Test Root Endpoint')


### PR DESCRIPTION
Implemented  a fixture for the "skip async test" function since all test in that file will requires Flask > 2.0
suggested by [jonasps](https://github.com/jonasps) and [greyli](https://github.com/greyli) 
apiflask/tests/test_async.py
Before
```
def skip_flask1(app):
    if not hasattr(app, 'ensure_sync'):
        pytest.skip('This test requires Flask 2.0 or higher')
```
After
```
@pytest.fixture(autouse=True)
def skip_async_test(app):
    if not hasattr(app, 'ensure_sync'):
        pytest.skip('This test requires Flask 2.0 or higher')
```
To improve it
- fixes #318 


Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the `docs` folder and in code docstring.
- [ ] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [ ] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [ ] Run `pytest` and `tox`, no tests failed.
