### PR TITLE
Improve CI setup and test against Python 3.10/3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,54 +1,60 @@
-name: build
+name: Tests
 on:
   push:
     branches:
       - main
+      - 'v*'
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
   pull_request:
     branches:
       - main
+      - 'v*'
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
 jobs:
-  lint:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - run: python -m pip install --upgrade pip wheel
-      - run: pip install tox tox-gh-actions
-      - run: tox -e style
-      - run: tox -e docs
-  flask1:
-    name: flask1
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - run: python -m pip install --upgrade pip wheel
-      - run: pip install tox tox-gh-actions
-      - run: tox -e flask1
   tests:
-    name: tests
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.7', '3.8', '3.9', 'pypy-3.8']
-      fail-fast: false
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {name: Linux, python: '3.10', os: ubuntu-latest, tox: py310}
+          - {name: Windows, python: '3.10', os: windows-latest, tox: py310}
+          - {name: Mac, python: '3.10', os: macos-latest, tox: py310}
+          - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
+          - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
+          - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
+          - {name: 'PyPy', python: 'pypy-3.7', os: ubuntu-latest, tox: pypy37}
+          - {name: Flask1, python: '3.8', os: ubuntu-latest, tox: flask1}
+          - {name: Style, python: '3.10', os: ubuntu-latest, tox: style}
+          - {name: Docs, python: '3.10', os: ubuntu-latest, tox: docs}
+          - {name: Typing, python: '3.10', os: ubuntu-latest, tox: typing}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-      - run: python -m pip install --upgrade pip wheel
-      - run: pip install tox tox-gh-actions
-      - run: tox
-  coverage:
-    name: coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - run: python -m pip install --upgrade pip wheel
-      - run: pip install tox tox-gh-actions codecov
-      - run: tox
-      - run: codecov
+          cache: 'pip'
+          cache-dependency-path: 'requirements/*.txt'
+      - name: update pip
+        run: |
+          pip install -U wheel
+          pip install -U setuptools
+          python -m pip install -U pip
+      - name: cache mypy
+        uses: actions/cache@v3.0.4
+        with:
+          path: ./.mypy_cache
+          key: mypy|${{ matrix.python }}|${{ hashFiles('setup.cfg') }}
+        if: matrix.tox == 'typing'
+      - run: pip install tox
+      - run: tox -e ${{ matrix.tox }}
+      - name: collect coverage
+        run: |
+          pip install codecov
+          codecov
+        if: matrix.name == 'Linux'

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -578,7 +578,7 @@ class APIFlask(APIScaffold, Flask):
 
         if self.spec_path:
             @bp.route(self.spec_path)
-            def spec() -> ResponseReturnValueType:
+            def spec():
                 if self.config['SPEC_FORMAT'] == 'json':
                     response = jsonify(self._get_spec('json'))
                     response.mimetype = self.config['JSON_SPEC_MIMETYPE']
@@ -594,7 +594,7 @@ class APIFlask(APIScaffold, Flask):
                 )
 
             @bp.route(self.docs_path)
-            def docs() -> str:
+            def docs():
                 return render_template_string(
                     ui_templates[self.docs_ui],
                     title=self.title,
@@ -610,7 +610,7 @@ class APIFlask(APIScaffold, Flask):
 
         if self.redoc_path:
             @bp.route(self.redoc_path)
-            def redoc() -> str:
+            def redoc():
                 warnings.warn(
                     'The `/redoc` path and `redoc_path` parameter is deprecated '
                     'and will be removed in 2.0, Set `APIFlask(docs_ui="redoc")` '

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = style,py37,py38,py39,pypy38,docs,mypy,flask1
+envlist =
+    py3{11,10,9,8,7},pypy3{8,7}
+    py310-min
+    py37-dev
+    style
+    typing
+    docs
+    flask1
 skip_missing_interpreters = True
-
-[gh-actions]
-python =
-    3.7: py37
-    3.8: py38, mypy, flask1
-    3.9: py39
-    pypy3.8: pypy38
 
 [testenv]
 deps =
@@ -27,7 +27,7 @@ deps = -r requirements/docs.txt
 whitelist_externals = mkdocs
 commands = mkdocs build
 
-[testenv:mypy]
+[testenv:typing]
 deps = -r requirements/typing.txt
 commands = mypy
 


### PR DESCRIPTION
- Test against Python 3.10, 3.11
- Follow Flask's CI setup
- Update setup-python to v4
- Add cache support for pip
- Ignore docs changes

fixes: #297
fixes: #298
fixes: #299