### PR TITLE
Set default Elements router to hash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@
 Released: -
 
 
+## Version 1.1.2
+
+Released: 2022/8/13
+
+- Set default Elements router to `hash` to fix incorrect path updates.
+
+
 ## Version 1.1.1
 
 Released: 2022/8/3

--- a/src/apiflask/ui_templates.py
+++ b/src/apiflask/ui_templates.py
@@ -207,6 +207,12 @@ elements_template = """
   <elements-api
     apiDescriptionUrl="{{ url_for('openapi.spec') }}"
     layout="{{ config.ELEMENTS_LAYOUT }}"
+    {% if config.ELEMENTS_CONFIG and 'router' in config.ELEMENTS_CONFIG %}
+      {% set router = config.ELEMENTS_CONFIG['router'] %}
+    {% else %}
+      {% set router = 'hash' %}
+    {% endif %}
+    router={{ router | tojson }}
     {% if config.ELEMENTS_CONFIG %}
       {% for key, value in config.ELEMENTS_CONFIG.items() %}
         {{ key }}={{ value | tojson }}

--- a/tests/test_settings_api_docs.py
+++ b/tests/test_settings_api_docs.py
@@ -92,6 +92,12 @@ def test_swagger_ui_oauth_config(app, client):
 
 def test_elements_config():
     app = APIFlask(__name__, docs_ui='elements')
+
+    rv = app.test_client().get('/docs')
+    assert rv.status_code == 200
+    # test default router
+    assert b'router="hash"' in rv.data
+
     app.config['ELEMENTS_CONFIG'] = {
         'hideTryIt': False,
         'router': 'memory'


### PR DESCRIPTION
So we don't need to handle the basePath value.