### PR TITLE
for compat with flask 2.2

### DIFF
--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -16,7 +16,11 @@ from flask import Flask
 from flask import jsonify
 from flask import render_template_string
 from flask.config import ConfigAttribute
-from flask.globals import _request_ctx_stack
+try:
+    from flask.globals import request_ctx
+except ImportError:
+    from flask.globals import _request_ctx_stack
+    request_ctx = None
 from flask.wrappers import Response
 
 with warnings.catch_warnings():
@@ -406,7 +410,7 @@ class APIFlask(APIScaffold, Flask):
 
         *Version added: 0.2.0*
         """
-        req = _request_ctx_stack.top.request
+        req = request_ctx.request if request_ctx else _request_ctx_stack.top.request
         if req.routing_exception is not None:
             self.raise_routing_exception(req)
         rule = req.url_rule

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -20,7 +20,7 @@ try:
     from flask.globals import request_ctx
 except ImportError:
     from flask.globals import _request_ctx_stack
-    request_ctx = None
+    request_ctx = None  # type: ignore
 from flask.wrappers import Response
 
 with warnings.catch_warnings():


### PR DESCRIPTION
1. In flask2.2,  use `_request_ctx_stack` will cause a warning, and it will be removed in flask2.3
2. In flask2.2, some unit test will raise [AssertionError](https://github.com/pallets/flask/blob/main/src/flask/app.py#L720). I try to mofidy the route order to fix this

some other unittest of flask2.2 can't pass is caused by the [class-based views issue](https://github.com/apiflask/apiflask/issues/341).


Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the `docs` folder and in code docstring.
- [ ] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [ ] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [X] Run `pytest` and `tox`, no tests failed.
