### PR TITLE
fix test base_response data key

### DIFF
--- a/tests/test_base_response.py
+++ b/tests/test_base_response.py
@@ -117,10 +117,7 @@ def test_base_response_spec(app, client, base_schema):
             assert schema['$ref'] == schema_ref
 
 
-# TODO pytest seems can't catch the ValueError happened in the output decorator
 def test_base_response_data_key(app, client):
-    pytest.skip()
-
     app.config['BASE_RESPONSE_SCHEMA'] = BaseResponse
     app.config['BASE_RESPONSE_DATA_KEY '] = 'data'
 
@@ -130,8 +127,9 @@ def test_base_response_data_key(app, client):
         data = {'id': '123', 'name': 'test'}
         return {'message': 'Success.', 'status_code': '200', 'info': data}
 
-    with pytest.raises(ValueError):
-        client.get('/')
+    with app.test_request_context('/'):
+        with pytest.raises(RuntimeError, match=r'The data key.*is not found in the returned dict.'):
+            foo()
 
 
 def test_base_response_204(app, client):


### PR DESCRIPTION
I think this test can't from the client side's request, maybe we can directly call the view function

Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the `docs` folder and in code docstring.
- [ ] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [ ] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [X] Run `pytest` and `tox`, no tests failed.
