### PR TITLE
Pin Flask < 2.2 as a temp fix for CBV support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name='APIFlask',
     install_requires=[
-        'flask >= 1.1.0',
+        'flask >= 1.1.0, < 2.2.0',
         'flask-marshmallow >= 0.12.0',
         'webargs >= 6',
         'flask-httpauth >= 4',

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -17,7 +17,7 @@ from flask import jsonify
 from flask import render_template_string
 from flask.config import ConfigAttribute
 try:
-    from flask.globals import request_ctx
+    from flask.globals import request_ctx  # type: ignore
 except ImportError:
     from flask.globals import _request_ctx_stack
     request_ctx = None  # type: ignore
@@ -410,7 +410,7 @@ class APIFlask(APIScaffold, Flask):
 
         *Version added: 0.2.0*
         """
-        req = request_ctx.request if request_ctx else _request_ctx_stack.top.request
+        req = request_ctx.request if request_ctx else _request_ctx_stack.top.request  # type: ignore
         if req.routing_exception is not None:
             self.raise_routing_exception(req)
         rule = req.url_rule


### PR DESCRIPTION
Flask changed the signature of the view function created by view classes in the 2.2 version (https://github.com/pallets/flask/pull/4624), which now only accepts keyword-only arguments.

Temp fix for #341.
