### PR TITLE
Fix Netlify build command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
   publish = "site"
-  command = "pip install . && pip install -r requirements/docs.txt && export PYTHONPATH=$(pwd) && mkdocs build"
+  command = "pip install -r requirements/docs.txt && pip install flask flask-marshmallow webargs flask-httpauth apispec && pip install . && export PYTHONPATH=$(pwd) && mkdocs build"


### PR DESCRIPTION
After changing the build image, the deployment will fail with `pip install .` (ModuleNotFound: flask-marshmallow). This is a temp fix for this issue, I install these packages before running the pip install command.