### PR TITLE
Improve endpoint bypassing for OpenAPI spec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,10 +9,14 @@ Released: -
 - Fix OpenAPI spec generating for path parameters when path schema is provided ([issue #350][issue_350]).
 - Add `spec_plugins` param to `APIFlask` class to support using custom apispec plugins ([issue #349][issue_349]).
 - Change the status code of request validation error from 400 to 422 ([issue #345][issue_345]).
+- Improve the default bypassing rules to support bypass blueprint's static endpoint and
+  Flask-DebugToolbar ([issue #344][issue_344], [issue #369][issue_369]).
 
 [issue_350]: https://github.com/apiflask/apiflask/issues/350
 [issue_349]: https://github.com/apiflask/apiflask/issues/349
 [issue_345]: https://github.com/apiflask/apiflask/issues/345
+[issue_344]: https://github.com/apiflask/apiflask/issues/344
+[issue_369]: https://github.com/apiflask/apiflask/issues/369
 
 
 ## Version 1.1.3

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -49,6 +49,7 @@ from .types import TagsType
 from .types import OpenAPISchemaType
 from .openapi import add_response
 from .openapi import add_response_with_schema
+from .openapi import default_bypassed_endpoints
 from .openapi import default_response
 from .openapi import get_tag
 from .openapi import get_operation_tags
@@ -906,8 +907,7 @@ class APIFlask(APIScaffold, Flask):
             operations: t.Dict[str, t.Any] = {}
             view_func: ViewFuncType = self.view_functions[rule.endpoint]  # type: ignore
             # skip endpoints from openapi blueprint and the built-in static endpoint
-            if rule.endpoint.startswith('openapi') or \
-               rule.endpoint.startswith('static'):
+            if rule.endpoint in default_bypassed_endpoints:
                 continue
             blueprint_name: t.Optional[str] = None  # type: ignore
             if '.' in rule.endpoint:
@@ -917,7 +917,8 @@ class APIFlask(APIScaffold, Flask):
                     # just a normal view with dots in its endpoint, reset blueprint_name
                     blueprint_name = None
                 else:
-                    if not hasattr(blueprint, 'enable_openapi') or \
+                    if rule.endpoint == (f'{blueprint_name}.static') or \
+                       not hasattr(blueprint, 'enable_openapi') or \
                        not blueprint.enable_openapi:  # type: ignore
                         continue
             # add a default 200 response for bare views

--- a/src/apiflask/openapi.py
+++ b/src/apiflask/openapi.py
@@ -15,6 +15,15 @@ if t.TYPE_CHECKING:  # pragma: no cover
     from .blueprint import APIBlueprint
 
 
+default_bypassed_endpoints: t.List[str] = [
+    'static',
+    'openapi.spec',
+    'openapi.docs',
+    'openapi.redoc',
+    'openapi.swagger_ui_oauth_redirect',
+    '_debug_toolbar.static',  # Flask-DebugToolbar
+]
+
 default_response = {
     'schema': {},
     'status_code': 200,

--- a/tests/test_openapi_basic.py
+++ b/tests/test_openapi_basic.py
@@ -6,6 +6,7 @@ from openapi_spec_validator import validate_spec
 from .schemas import Bar
 from .schemas import Baz
 from .schemas import Foo
+from apiflask import APIBlueprint
 from apiflask import Schema as BaseSchema
 from apiflask.fields import Integer
 
@@ -55,6 +56,20 @@ def test_get_spec_force_update(app):
 
     new_spec = app._get_spec(force_update=True)
     assert '/foo' in new_spec['paths']
+
+
+def test_spec_bypass_endpoints(app):
+
+    bp = APIBlueprint('foo', __name__, static_folder='static', url_prefix='/foo')
+    app.register_blueprint(bp)
+
+    spec = app._get_spec()
+    assert '/static' not in spec['paths']
+    assert '/foo/static' not in spec['paths']
+    assert '/docs' not in spec['paths']
+    assert '/openapi.json' not in spec['paths']
+    assert '/redoc' not in spec['paths']
+    assert '/docs/oauth2-redirect' not in spec['paths']
 
 
 def test_spec_attribute(app):


### PR DESCRIPTION
- Fix the bypass for the Blueprint static endpoint
- Improve the bypass rule for static and OpenAPI endpoints
- Add bypass rule for Flask-DebugToolbar

<!--
For features and bug fixes, before opening a PR, please open an issue describing
the bug or feature the PR will address. You can skip this step if it's a typo fix.

Replace this comment with a description of the change. Describe how it
addresses the linked issue.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

fixes #344
fixes #369

<!--
If needed, ensure each step in the checklist below is complete. If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
