### PR TITLE
Set schema fields in order by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ Released: -
 - Improve the default bypassing rules to support bypass blueprint's static endpoint and
   Flask-DebugToolbar ([issue #344][issue_344], [issue #369][issue_369]).
 - Explicitly check if `view_func.view_class` is `MethodViewType` in `add_url_rule` ([issue #379][issue_379]).
+- The schema fields are now in order by default, which ensures the output of `flask spec` is deterministic
+  ([issue #373][issue_373]).
 
 [issue_350]: https://github.com/apiflask/apiflask/issues/350
 [issue_349]: https://github.com/apiflask/apiflask/issues/349
@@ -19,6 +21,7 @@ Released: -
 [issue_344]: https://github.com/apiflask/apiflask/issues/344
 [issue_369]: https://github.com/apiflask/apiflask/issues/369
 [issue_379]: https://github.com/apiflask/apiflask/issues/379
+[issue_373]: https://github.com/apiflask/apiflask/issues/373
 
 
 ## Version 1.1.3

--- a/README.md
+++ b/README.md
@@ -268,9 +268,9 @@ In a word, to make Web API development in Flask more easily, APIFlask provides `
 
 APIFlask accepts marshmallow schema as data schema, uses webargs to validate the request data against the schema, and uses apispec to generate the OpenAPI representation from the schema.
 
-You can build marshmallow schemas just like before, but APIFlask also exposes some marshmallow APIs for convenience (it's optional, you can still import everything from marshamallow directly):
+You can build marshmallow schemas just like before, but APIFlask also exposes some marshmallow APIs for convenience:
 
-- `apiflask.Schema`: The base marshmallow schema class.
+- `apiflask.Schema`: The base marshmallow schema class. Notice it sets the `set_class` to `OrderedSet` by default.
 - `apiflask.fields`: The marshmallow fields, contain the fields from both marshmallow and Flask-Marshmallow. Beware that the aliases (`Url`, `Str`, `Int`, `Bool`, etc.) were removed.
 - `apiflask.validators`: The marshmallow validators.
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -5,9 +5,8 @@ section first in the Basic Usage chapter for the basics of writing input and out
 
 Basic concepts on data schema:
 
-- APIFlask schema = [marshmallow](https://github.com/marshmallow-code/marshmallow) schema.
-- APIFlask's `apiflask.Schema` base class is directly imported from marshmallow, see the
-  [API documentation](https://marshmallow.readthedocs.io/en/stable/marshmallow.schema.html)
+- APIFlask's `apiflask.Schema` base class is directly imported from marshmallow with some minor changes,
+  see the [API documentation](https://marshmallow.readthedocs.io/en/stable/marshmallow.schema.html)
   for the details.
 - We recommend separating input and output schema. Since the output data is not
   validated, you don't need to define validators on output fields.

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -862,7 +862,7 @@ class APIFlask(APIScaffold, Flask):
             kwargs['externalDocs'] = self.external_docs
 
         ma_plugin: MarshmallowPlugin = MarshmallowPlugin(
-            schema_name_resolver=self.schema_name_resolver
+            schema_name_resolver=self.schema_name_resolver  # type: ignore
         )
 
         spec_plugins: t.List[BasePlugin] = [ma_plugin, *self.spec_plugins]

--- a/src/apiflask/schemas.py
+++ b/src/apiflask/schemas.py
@@ -1,8 +1,9 @@
 import typing as t
 
-from marshmallow import Schema as Schema
+from marshmallow import Schema as BaseSchema
 from marshmallow.fields import Integer
 from marshmallow.fields import URL
+from marshmallow.orderedset import OrderedSet
 
 
 # schema for the detail object of validation error response
@@ -48,6 +49,19 @@ http_error_schema: t.Dict[str, t.Any] = {
     },
     'type': 'object'
 }
+
+
+class Schema(BaseSchema):
+    """A base schema for all schemas.
+
+    The different between marshmallow's `Schema` and APIFlask's `Schema` is that the latter
+    sets `set_class` to `OrderedSet` by default.
+
+    *Version Added: 1.2.0*
+    """
+    # use ordered set to keep the order of fields
+    # can be removed when https://github.com/marshmallow-code/marshmallow/pull/1896 is merged
+    set_class = OrderedSet
 
 
 class EmptySchema(Schema):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from .schemas import Foo
 from apiflask.commands import spec_command
 
 
@@ -17,6 +18,21 @@ def test_flask_spec_output(app, cli_runner, tmp_path):
     assert 'openapi' in result.output
     with open(local_spec_path) as f:
         assert json.loads(f.read()) == app.spec
+
+
+def test_flask_spec_fields_order(app, cli_runner):
+    @app.get('/foo')
+    @app.output(Foo)
+    def foo():
+        pass
+
+    result = cli_runner.invoke(spec_command)
+    assert 'openapi' in result.output
+    assert json.loads(result.output) == app.spec
+    assert (
+        list(json.loads(result.output)['components']['schemas']['Foo']['properties'].keys())
+        == ['id', 'name']
+    )
 
 
 @pytest.mark.parametrize('format', ['json', 'yaml', 'yml', 'foo'])


### PR DESCRIPTION
When generating the spec file with the `flask spec` command, the output should be deterministic. This PR changes the default set class of `Schema` class to `OrderedSet`, so that the schema fields will be in order by default. 

P.S. There is already a PR in marshmallow for this (https://github.com/marshmallow-code/marshmallow/pull/1896). We can remove this change when that PR is merged.

- fixes #373
- fixes #385

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code docstring.
- [x] Add *Version changed* or *Version added* note in any relevant docs and docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Run `pytest` and `tox`, no tests failed.
