### PR TITLE
Support generating a default `servers` field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 Released: -
 
+- Support to generate the OpenAPI `servers` field when the reqeust context is available. Add
+  the config `AUTO_SERVERS` to control this automation behavior ([issue #377][issue_377]).
+
+[issue_377]: https://github.com/apiflask/apiflask/issues/377
+
 
 ## Version 1.2.0
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -542,6 +542,10 @@ app.config['AUTO_TAGS'] = False
 
 ### AUTO_SERVERS
 
+!!! warning "Version >= 1.2.1"
+
+    This configuration variable was added in the [version 1.2.1](/changelog/#version-121).
+
 Enable or disable auto servers (`openapi.servers`) generation from the request context.
 
 It's useful when you are running the API behind a reverse proxy with a URL prefix.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,12 +143,19 @@ The server information of the API (`openapi.servers`), accepts multiple
 server dicts. This configuration can also be configured from the `app.servers`
 attribute.
 
+[`AUTO_SERVERS`](/configuration#auto_servers) config is default to `True`, which
+means the server information will be set automatically when the request context is available.
+
 - Type: `List[Dict[str, str]]`
 - Default value: `None`
 - Examples:
 
 ```python
 app.config['SERVERS'] = [
+    {
+        'name': 'Dev Server',
+        'url': 'http://localhost:5000'
+    },
     {
         'name': 'Production Server',
         'url': 'http://api.example.com'
@@ -160,6 +167,10 @@ Or:
 
 ```python
 app.servers = [
+    {
+        'name': 'Dev Server',
+        'url': 'http://localhost:5000'
+    },
     {
         'name': 'Production Server',
         'url': 'http://api.example.com'
@@ -526,6 +537,27 @@ Enable or disable auto tags (`openapi.tags`) generation from the name of the blu
 
 ```python
 app.config['AUTO_TAGS'] = False
+```
+
+
+### AUTO_SERVERS
+
+Enable or disable auto servers (`openapi.servers`) generation from the request context.
+
+It's useful when you are running the API behind a reverse proxy with a URL prefix.
+
+Notice the `servers` field will not exist when the request context is not available (e.g. `flask spec`).
+
+!!! tip
+
+    This automation behavior only happens when `app.servers` or config `SERVERS` is not set.
+
+- Type: `bool`
+- Default value: `True`
+- Examples:
+
+```python
+app.config['AUTO_SERVERS'] = False
 ```
 
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -26,6 +26,8 @@ it with `@app.doc` decorator and configuration variables.
 documentation tools.
 - **[Configuration](/configuration)**: A list of all the built-in configuration variables
 - **[Examples](/examples)**: A collection of application examples.
+- **[Tips](/tips)**: A collection of best practices and notes for web API development with APIFlask.
+
 
 The following chapters are useful for contributors and who want to know more about
 APIFlask:

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -38,10 +38,10 @@ server {
 }
 ```
 
-??? notes
+!!! notes
 
-    APIFlask will update the OpenAPI's `servers` field automatically. If you
-    set the `AUTO_SERVERS` config to `False`, then you will need to update
+    From version 1.2.1, APIFlask will update the OpenAPI's `servers` field automatically.
+    If you set the `AUTO_SERVERS` config to `False`, then you will need to update
     the `servers` field manually to specify the URL prefix:
 
     ```python

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -1,0 +1,69 @@
+# Tips
+
+## Running the application behide a reverse proxy
+
+If you are running the application behind a reverse proxy (e.g. Nginx),
+you will need to set the config file like this:
+
+```
+server {
+    listen 80;
+    server_name _;
+
+    location / {
+        proxy_pass http://127.0.0.1:5000/;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Prefix /;
+    }
+}
+```
+
+If your application is running on a different URL prefix, you need to change
+both the location and the `X-Forwarded-Prefix` header:
+
+```hl_lines="5 10"
+server {
+    listen 80;
+    server_name _;
+
+    location /api {
+        proxy_pass http://127.0.0.1:5000/;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Prefix /api;
+    }
+}
+```
+
+??? notes
+
+    APIFlask will update the OpenAPI's `servers` field automatically. If you
+    set the `AUTO_SERVERS` config to `False`, then you will need to update
+    the `servers` field manually to specify the URL prefix:
+
+    ```python
+    app.config['SERVERS'] = [{'url': '/api'}]
+    ```
+
+
+Then apply the proxy fix middleware for your application:
+
+```python
+from werkzeug.middleware.proxy_fix import ProxyFix
+from apiflask import APIFlask
+
+
+app = APIFlask(__name__)
+app.wsgi_app = ProxyFix(
+    app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1
+)
+```
+
+
+See also:
+
+- [Deploying with Nginx](https://flask.palletsprojects.com/deploying/nginx/)
+- [Tell Flask it is Behind a Proxy](https://flask.palletsprojects.com/deploying/proxy_fix/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
   - Configuration: configuration.md
   - Error Handling: error-handling.md
   - Examples: examples.md
+  - Tips: tips.md
   - API Reference:
     - APIFlask: api/app.md
     - APIBlueprint: api/blueprint.md

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -14,8 +14,10 @@ from apispec import BasePlugin
 from apispec.ext.marshmallow import MarshmallowPlugin
 from flask import Blueprint
 from flask import Flask
+from flask import has_request_context
 from flask import jsonify
 from flask import render_template_string
+from flask import request
 from flask.config import ConfigAttribute
 try:
     from flask.globals import request_ctx  # type: ignore
@@ -843,6 +845,10 @@ class APIFlask(APIScaffold, Flask):
     def _generate_spec(self) -> APISpec:
         """Generate the spec, return an instance of `apispec.APISpec`.
 
+        *Version changed: 1.2.1*
+
+        - Set default `servers` value.
+
         *Version changed: 0.10.0*
 
         - Add support for `operationId`.
@@ -859,6 +865,9 @@ class APIFlask(APIScaffold, Flask):
         kwargs: dict = {}
         if self.servers:
             kwargs['servers'] = self.servers
+        else:
+            if self.config['AUTO_SERVERS'] and has_request_context():
+                kwargs['servers'] = [{'url': request.url_root}]
         if self.external_docs:
             kwargs['externalDocs'] = self.external_docs
 

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -608,7 +608,8 @@ class APIFlask(APIScaffold, Flask):
             if self.docs_ui not in ui_templates:
                 valid_values = list(ui_templates.keys())
                 raise ValueError(
-                    f'Invalid docs_ui value, expected one of {valid_values}, got "{self.docs_ui}".'
+                    f'Invalid docs_ui value, expected one of {valid_values!r}, '
+                    f'got {self.docs_ui!r}.'
                 )
 
             @bp.route(self.docs_path)
@@ -1056,7 +1057,7 @@ class APIFlask(APIScaffold, Flask):
                         data_key: str = self.config['BASE_RESPONSE_DATA_KEY']
                         if data_key not in base_schema_spec['properties']:
                             raise RuntimeError(
-                                f'The data key "{data_key}" is not found in'
+                                f'The data key {data_key!r} is not found in'
                                 ' the base response schema spec.'
                             )
                         base_schema_spec['properties'][data_key] = schema

--- a/src/apiflask/exceptions.py
+++ b/src/apiflask/exceptions.py
@@ -71,7 +71,7 @@ class HTTPError(Exception):
             # TODO: support use custom error status code?
             if status_code not in default_exceptions:
                 raise LookupError(
-                    f'No exception for status code "{status_code}",'
+                    f'No exception for status code {status_code!r},'
                     ' valid error status code are "4XX" and "5XX".'
                 )
             self.status_code = status_code

--- a/src/apiflask/scaffold.py
+++ b/src/apiflask/scaffold.py
@@ -303,7 +303,7 @@ class APIScaffold:
                 raise ValueError(
                     'Unknown input location. The supported locations are: "json", "files",'
                     ' "form", "cookies", "headers", "query" (same as "querystring"), "path"'
-                    f' (same as "view_args") and "form_and_files". Got "{location}" instead.'
+                    f' (same as "view_args") and "form_and_files". Got {location!r} instead.'
                 )
             if location == 'json':
                 _annotate(f, body=schema, body_example=example, body_examples=examples)
@@ -468,7 +468,7 @@ class APIScaffold:
                     data_key: str = current_app.config['BASE_RESPONSE_DATA_KEY']
                     if data_key not in obj:
                         raise RuntimeError(
-                            f'The data key "{data_key}" is not found in the returned dict.'
+                            f'The data key {data_key!r} is not found in the returned dict.'
                         )
                     obj[data_key] = schema.dump(obj[data_key], many=many)  # type: ignore
                     data = base_schema().dump(obj)  # type: ignore

--- a/src/apiflask/settings.py
+++ b/src/apiflask/settings.py
@@ -26,6 +26,7 @@ LOCAL_SPEC_JSON_INDENT: int = 2
 SYNC_LOCAL_SPEC: t.Optional[bool] = None
 # Automation behavior control
 AUTO_TAGS: bool = True
+AUTO_SERVERS: bool = True
 AUTO_OPERATION_SUMMARY: bool = True
 AUTO_OPERATION_DESCRIPTION: bool = True
 AUTO_OPERATION_ID: bool = False

--- a/tests/test_settings_auto_behaviour.py
+++ b/tests/test_settings_auto_behaviour.py
@@ -25,6 +25,15 @@ def test_auto_tags(app, client):
 
 
 @pytest.mark.parametrize('config_value', [True, False])
+def test_auto_servers(app, client, config_value):
+    app.config['AUTO_SERVERS'] = config_value
+    rv = client.get('/openapi.json')
+    assert rv.status_code == 200
+    validate_spec(rv.json)
+    assert bool('servers' in rv.json) == config_value
+
+
+@pytest.mark.parametrize('config_value', [True, False])
 def test_auto_path_summary(app, client, config_value):
     app.config['AUTO_OPERATION_SUMMARY'] = config_value
 


### PR DESCRIPTION
- Set default `servers` field
- Add `AUTO_SERVERS` config
- Add `Tips` docs chapter

<!--
For features and bug fixes, before opening a PR, please open an issue describing
the bug or feature the PR will address. You can skip this step if it's a typo fix.

Replace this comment with a description of the change. Describe how it
addresses the linked issue.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

fixes #377
fixes #334

<!--
If needed, ensure each step in the checklist below is complete. If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
