### PR TITLE
Fix the not-iterable exception occurred when directly returning a custom class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,12 @@ Released: -
 
 - Remove the validation of input locations ([issue #259][issue_259]).
 - Support passing `Function` type config to `SWAGGER_UI_CONFIG` ([issue #381][issue_381]).
+- Fix the base response support so that a custom class can be returned from
+  the view function ([issue #384][issue_384]).
 
 [issue_259]: https://github.com/apiflask/apiflask/issues/259
 [issue_381]: https://github.com/apiflask/apiflask/issues/381
+[issue_384]: https://github.com/apiflask/apiflask/issues/384
 
 
 ## Version 1.2.1


### PR DESCRIPTION
Fix the not-iterable exception occurred when a `@app.output()` decorated view function directly return a custom class.

<!--
For features and bug fixes, before opening a PR, please open an issue describing
the bug or feature the PR will address. You can skip this step if it's a typo fix.

Replace this comment with a description of the change. Describe how it
addresses the linked issue.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

fixes #384

<!--
If needed, ensure each step in the checklist below is complete. If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [ ] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
