### PR TITLE
Bypass OpenAPI spec generation for view methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 Released: -
 
+- Bypass OpenAPI spec generation for view methods ([issue #406][issue_406]).
+
+[issue_406]: https://github.com/apiflask/apiflask/issues/406
+
 
 ## Version 1.2.2
 

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import re
 import sys
@@ -934,7 +935,7 @@ class APIFlask(APIScaffold, Flask):
                         continue
             # add a default 200 response for bare views
             if not hasattr(view_func, '_spec'):
-                if self.config['AUTO_200_RESPONSE']:
+                if not inspect.ismethod(view_func) and self.config['AUTO_200_RESPONSE']:
                     view_func._spec = {'response': default_response}
                 else:
                     continue  # pragma: no cover

--- a/tests/test_openapi_basic.py
+++ b/tests/test_openapi_basic.py
@@ -74,6 +74,18 @@ def test_spec_bypass_endpoints(app):
     assert '/docs/oauth2-redirect' not in spec['paths']
 
 
+def test_spec_bypass_methods(app):
+
+    class Foo:
+        def bar(self):
+            pass
+
+    app.add_url_rule('/foo', 'foo', Foo().bar)
+
+    spec = app._get_spec()
+    assert '/foo' not in spec['paths']
+
+
 def test_spec_attribute(app):
     spec = app._get_spec()
 


### PR DESCRIPTION
Some Flask extensions use add_url_rule to create routes from methods.

Related PR:

- https://github.com/apiflask/apiflask/pull/375
- https://github.com/apiflask/apiflask/pull/347

<!--
For features and bug fixes, before opening a PR, please open an issue describing
the bug or feature the PR will address. You can skip this step if it's a typo fix.

Replace this comment with a description of the change. Describe how it
addresses the linked issue.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

fixes #406

<!--
If needed, ensure each step in the checklist below is complete. If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [x] Run `pytest` and `tox`, no tests failed.
