### PR TITLE
Add `security_scheme_name` to customize OpenAPI security key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+
+## Version 1.3.0
+
+- Add `scurity_scheme_name` for `HTTPBasicAuth` and `HTTPTokenAuth` to define custom
+OpenAPI security scheme name ([issue #410][issue_410]).
+
+[issue_410]: https://github.com/apiflask/apiflask/issues/410
+
+
 ## Version 1.2.4
 
 Released: -

--- a/src/apiflask/openapi.py
+++ b/src/apiflask/openapi.py
@@ -71,16 +71,20 @@ def get_auth_name(
     auth_names: t.List[str]
 ) -> str:
     """Get auth name from auth object."""
-    name: str
-    if isinstance(auth, HTTPBasicAuth):
-        name = 'BasicAuth'
-    elif isinstance(auth, HTTPTokenAuth):
-        if auth.scheme.lower() == 'bearer' and auth.header is None:
-            name = 'BearerAuth'
+    name: str = ''
+    if hasattr(auth, 'security_scheme_name'):
+        name = auth.security_scheme_name  # type: ignore
+    if not name:
+        if isinstance(auth, HTTPBasicAuth):
+            name = 'BasicAuth'
+        elif isinstance(auth, HTTPTokenAuth):
+            if auth.scheme.lower() == 'bearer' and auth.header is None:
+                name = 'BearerAuth'
+            else:
+                name = 'ApiKeyAuth'
         else:
-            name = 'ApiKeyAuth'
-    else:
-        raise TypeError('Unknown authentication scheme.')
+            raise TypeError('Unknown authentication scheme.')
+
     if name in auth_names:
         v = 2
         new_name = f'{name}_{v}'

--- a/src/apiflask/security.py
+++ b/src/apiflask/security.py
@@ -13,8 +13,13 @@ from .types import ResponseReturnValueType
 class _AuthBase:
     """Base class for `HTTPBasicAuth` and `HTTPBasicAuth`."""
 
-    def __init__(self, description: t.Optional[str] = None) -> None:
+    def __init__(
+        self,
+        description: t.Optional[str] = None,
+        security_scheme_name: t.Optional[str] = None,
+    ) -> None:
         self.description = description
+        self.security_scheme_name = security_scheme_name
         self.error_handler(self._auth_error_handler)  # type: ignore
 
     @property
@@ -88,13 +93,18 @@ class HTTPBasicAuth(_AuthBase, BaseHTTPBasicAuth):
     app = APIFlask(__name__)
     auth = HTTPBasicAuth()
     ```
+
+    *Version changed: 1.3.0*
+
+    - Add `security_scheme_name` parameter.
     """
 
     def __init__(
         self,
         scheme: str = 'Basic',
         realm: t.Optional[str] = None,
-        description: t.Optional[str] = None
+        description: t.Optional[str] = None,
+        security_scheme_name: t.Optional[str] = None,
     ) -> None:
         """Initialize an `HTTPBasicAuth` object.
 
@@ -103,10 +113,11 @@ class HTTPBasicAuth(_AuthBase, BaseHTTPBasicAuth):
                 header. Defaults to `'Basic'`.
             realm: The realm used in the `WWW-Authenticate` header to indicate
                 a scope of protection, defaults to use `'Authentication Required'`.
-            description: The description of the security scheme.
+            description: The description of the OpenAPI security scheme.
+            security_scheme_name: The name of the OpenAPI security scheme, default to `BasicAuth`.
         """
         BaseHTTPBasicAuth.__init__(self, scheme=scheme, realm=realm)
-        super().__init__(description=description)
+        super().__init__(description=description, security_scheme_name=security_scheme_name)
 
 
 class HTTPTokenAuth(_AuthBase, BaseHTTPTokenAuth):
@@ -131,7 +142,8 @@ class HTTPTokenAuth(_AuthBase, BaseHTTPTokenAuth):
         scheme: str = 'Bearer',
         realm: t.Optional[str] = None,
         header: t.Optional[str] = None,
-        description: t.Optional[str] = None
+        description: t.Optional[str] = None,
+        security_scheme_name: t.Optional[str] = None,
     ) -> None:
         """Initialize a `HTTPTokenAuth` object.
 
@@ -148,7 +160,13 @@ class HTTPTokenAuth(_AuthBase, BaseHTTPTokenAuth):
                 X-API-Key: this-is-my-token
                 ```
 
-            description: The description of the security scheme.
+            description: The description of the OpenAPI security scheme.
+            security_scheme_name: The name of the OpenAPI security scheme,
+                defaults to `BearerAuth` or `ApiKeyAuth`.
+
+        *Version changed: 1.3.0*
+
+        - Add `security_scheme_name` parameter.
         """
         BaseHTTPTokenAuth.__init__(self, scheme=scheme, realm=realm, header=header)
-        super().__init__(description=description)
+        super().__init__(description=description, security_scheme_name=security_scheme_name)

--- a/tests/test_settings_openapi_fields.py
+++ b/tests/test_settings_openapi_fields.py
@@ -137,6 +137,7 @@ def test_security_shemes(app, client):
     rv = client.get('/openapi.json')
     assert rv.status_code == 200
     validate_spec(rv.json)
+    assert len(rv.json['components']['securitySchemes']) == 2
     assert rv.json['components']['securitySchemes']['ApiKeyAuth'] == \
         app.config['SECURITY_SCHEMES']['ApiKeyAuth']
     assert rv.json['components']['securitySchemes']['BasicAuth'] == \


### PR DESCRIPTION
Example usage:

```py
auth = HTTPTokenAuth(header="X-Example-Key", security_scheme_name="api_token")
```

Generated spec:

```json
"securitySchemes":{"api_token":{"in":"header","name":"X-Example-Key","type":"apiKey"}}
```

fixes #410

<!--
If needed, ensure each step in the checklist below is complete. If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
