### PR TITLE
Support passing APISpec object to spec processor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+
+## Version 1.3.0
+
+- Add config `SPEC_PROCESSOR_PASS_OBJECT` to control the argument type of
+  spec processor. The `spec` argument will be an `apispec.APISpec` object
+  when this config is `True` ([issue #213][issue_213]).
+
+[issue_213]: https://github.com/apiflask/apiflask/issues/213
+
+
 ## Version 1.2.4
 
 Released: -

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -516,6 +516,24 @@ app.config['YAML_SPEC_MIMETYPE'] = 'text/x-yaml'
     This configuration variable was added in the [version 0.4.0](/changelog/#version-040).
 
 
+### SPEC_PROCESSOR_PASS_OBJECT
+
+If `True`, the `spec` argument passed to the spec processor will be an
+[`apispec.APISpec`](https://apispec.readthedocs.io/en/latest/api_core.html#apispec.APISpec) object.
+
+- Type: `bool`
+- Default value: `False`
+- Examples:
+
+```python
+app.config['SPEC_PROCESSOR_PASS_OBJECT'] = True
+```
+
+!!! warning "Version >= 1.3.0"
+
+    This configuration variable was added in the [version 1.3.0](/changelog/#version-130).
+
+
 ## Automation behavior control
 
 The following configuration variables are used to control the automation behavior

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -920,11 +920,25 @@ def update_spec(spec):
     return spec
 ```
 
-Notice the format of the spec depends on the value of the configuration
-variable `SPEC_FORMAT` (defaults to `'json'`):
+By default, the `spec` argument is a dict. When the `SPEC_PROCESSOR_PASS_OBJECT` config is
+`True`, the `spec` argument will be an
+[`apispec.APISpec`](https://apispec.readthedocs.io/en/latest/api_core.html#apispec.APISpec) object.
 
-- `'json'` -> dict
-- `'yaml'` -> string
+```python
+from apiflask import APIFlask
+
+app = APIFlask(__name__)
+app.config['SPEC_PROCESSOR_PASS_OBJECT'] = True
+
+class FooSchema(Schema):
+    id = Integer()
+
+@app.spec_processor
+def update_spec(spec):
+    spec.title = 'Updated Title'
+    spec.components.schema('Foo', schema=FooSchema)  # add a schema manually
+    return spec
+```
 
 Check out [the example application](https://github.com/apiflask/apiflask/tree/main/examples/openapi/app.py)
 for OpenAPI support, see [the examples page](/examples) for running the example application.

--- a/src/apiflask/settings.py
+++ b/src/apiflask/settings.py
@@ -24,6 +24,7 @@ JSON_SPEC_MIMETYPE: str = 'application/json'
 LOCAL_SPEC_PATH: t.Optional[str] = None
 LOCAL_SPEC_JSON_INDENT: int = 2
 SYNC_LOCAL_SPEC: t.Optional[bool] = None
+SPEC_PROCESSOR_PASS_OBJECT: bool = False
 # Automation behavior control
 AUTO_TAGS: bool = True
 AUTO_SERVERS: bool = True
@@ -71,3 +72,6 @@ RAPIPDF_CONFIG: t.Optional[dict] = None
 
 # Version changed: 1.2.0
 # Change VALIDATION_ERROR_STATUS_CODE from 400 to 422.
+
+# Version added: 1.3.0
+# SPEC_PROCESSOR_PASS_OBJECT


### PR DESCRIPTION
Add a `SPEC_PROCESSOR_PASS_OBJECT` to control the argument type of the spec processor. Example usage:

```python
from apiflask import APIFlask

app = APIFlask(__name__)
app.config['SPEC_PROCESSOR_PASS_OBJECT'] = True

class FooSchema(Schema):
    id = Integer()

@app.spec_processor
def update_spec(spec):
    spec.title = 'Updated Title'
    spec.components.schema('Foo', schema=FooSchema)  # add a schema manually
    return spec
```

fixes #213

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
