### PR TITLE
Update dependencies and remove outdated code & docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,13 +22,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: Linux, python: '3.10', os: ubuntu-latest, tox: py310}
-          - {name: Windows, python: '3.10', os: windows-latest, tox: py310}
-          - {name: Mac, python: '3.10', os: macos-latest, tox: py310}
+          - {name: Linux, python: '3.11', os: ubuntu-latest, tox: py311}
+          - {name: Windows, python: '3.11', os: windows-latest, tox: py311}
+          - {name: Mac, python: '3.11', os: macos-latest, tox: py311}
+          - {name: '3.10', python: '3.10', os: ubuntu-latest, tox: py310}
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
-          - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
-          - {name: 'PyPy', python: 'pypy-3.7', os: ubuntu-latest, tox: pypy37}
+          - {name: 'PyPy', python: 'pypy-3.10', os: ubuntu-latest, tox: pypy310}
           - {name: Style, python: '3.10', os: ubuntu-latest, tox: style}
           - {name: Docs, python: '3.10', os: ubuntu-latest, tox: docs}
           - {name: Typing, python: '3.10', os: ubuntu-latest, tox: typing}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ APIFlask 2.0 project: https://github.com/apiflask/apiflask/projects/4
 
 Released: -<br>Codename: Gongqing
 
+- Drop Python 3.7 support.
 - Drop Flask 1.x support ([issue #442][issue_442]).
 - Only pass keyword arguments to the view function. The argument name
   of the parsed data from `app.input()` will be `{location}_data` or the

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ With APIFlask, you will have:
 
 ## Requirements
 
-- Python 3.7+
+- Python 3.8+
 - Flask 2.0+
 
 
@@ -167,7 +167,7 @@ app.add_url_rule('/pets/<int:pet_id>', view_func=Pet.as_view('pet'))
 </details>
 
 <details>
-<summary>Or use <code>async def</code> with Flask 2.0</summary>
+<summary>Or use <code>async def</code></summary>
 
 ```bash
 $ pip install -U "apiflask[async]"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,8 +5,8 @@ This chapter will cover the primary usage of APIFlask.
 
 ## Prerequisites
 
-- Python 3.7+
-- Flask 1.1+
+- Python 3.8+
+- Flask 2.2+
 
 You also need to know the basic of Flask. Here are some useful free resources
 to learn Flask:

--- a/examples/orm/app.py
+++ b/examples/orm/app.py
@@ -49,7 +49,7 @@ def say_hello():
 @app.get('/pets/<int:pet_id>')
 @app.output(PetOut)
 def get_pet(pet_id):
-    return PetModel.query.get_or_404(pet_id)
+    return db.get_or_404(PetModel, pet_id)
 
 
 @app.get('/pets')
@@ -72,7 +72,7 @@ def create_pet(json_data):
 @app.input(PetIn(partial=True), location='json')
 @app.output(PetOut)
 def update_pet(pet_id, json_data):
-    pet = PetModel.query.get_or_404(pet_id)
+    pet = db.get_or_404(PetModel, pet_id)
     for attr, value in json_data.items():
         setattr(pet, attr, value)
     db.session.commit()
@@ -82,7 +82,7 @@ def update_pet(pet_id, json_data):
 @app.delete('/pets/<int:pet_id>')
 @app.output({}, status_code=204)
 def delete_pet(pet_id):
-    pet = PetModel.query.get_or_404(pet_id)
+    pet = db.get_or_404(PetModel, pet_id)
     db.session.delete(pet)
     db.session.commit()
     return ''

--- a/examples/pagination/app.py
+++ b/examples/pagination/app.py
@@ -52,14 +52,15 @@ def say_hello():
 @app.get('/pets/<int:pet_id>')
 @app.output(PetOut)
 def get_pet(pet_id):
-    return PetModel.query.get_or_404(pet_id)
+    return db.get_or_404(PetModel, pet_id)
 
 
 @app.get('/pets')
 @app.input(PetQuery, location='query')
 @app.output(PetsOut)
 def get_pets(query_data):
-    pagination = PetModel.query.paginate(
+    pagination = db.paginate(
+        db.select(PetModel),
         page=query_data['page'],
         per_page=query_data['per_page']
     )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,13 +83,13 @@ plugins:
       default_handler: python
       handlers:
         python:
-          rendering:
+          options:
             heading_level: 2
-      watch:
-        - src/apiflask
-        - README.md
-        - examples/README.md
-        - CHANGES.md
-        - CONTRIBUTING.md
+watch:
+  - src/apiflask
+  - README.md
+  - examples/README.md
+  - CHANGES.md
+  - CONTRIBUTING.md
 extra_css:
   - _assets/extra.css

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,7 +19,7 @@ chardet==5.1.0
     # via tox
 distlib==0.3.6
     # via virtualenv
-filelock==3.12.1
+filelock==3.12.2
     # via
     #   tox
     #   virtualenv
@@ -29,23 +29,23 @@ nodeenv==1.8.0
     # via pre-commit
 pip-compile-multi==2.6.3
     # via -r requirements/dev.in
-pip-tools==6.13.0
+pip-tools==7.0.0
     # via pip-compile-multi
-platformdirs==3.5.3
+platformdirs==3.8.1
     # via
     #   tox
     #   virtualenv
-pre-commit==3.3.2
+pre-commit==3.3.3
     # via -r requirements/dev.in
-pyproject-api==1.5.1
+pyproject-api==1.5.3
     # via tox
 pyproject-hooks==1.0.0
     # via build
 toposort==1.10
     # via pip-compile-multi
-tox==4.6.0
+tox==4.6.4
     # via -r requirements/dev.in
-virtualenv==20.23.0
+virtualenv==20.24.0
     # via
     #   pre-commit
     #   tox

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,9 +7,9 @@
 #
 certifi==2023.5.7
     # via requests
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
-click==8.1.3
+click==8.1.5
     # via mkdocs
 colorama==0.4.6
     # via
@@ -17,7 +17,7 @@ colorama==0.4.6
     #   mkdocs-material
 ghp-import==2.1.0
     # via mkdocs
-griffe==0.29.0
+griffe==0.32.1
     # via mkdocstrings-python
 idna==3.4
     # via requests
@@ -46,7 +46,7 @@ mkdocs==1.4.3
     #   mkdocstrings
 mkdocs-autorefs==0.4.1
     # via mkdocstrings
-mkdocs-material==9.1.15
+mkdocs-material==9.1.18
     # via -r requirements/docs.in
 mkdocs-material-extensions==1.1.1
     # via mkdocs-material
@@ -54,13 +54,13 @@ mkdocstrings==0.22.0
     # via
     #   -r requirements/docs.in
     #   mkdocstrings-python
-mkdocstrings-python==1.1.2
+mkdocstrings-python==1.2.0
     # via -r requirements/docs.in
 packaging==23.1
     # via mkdocs
 pygments==2.15.1
     # via mkdocs-material
-pymdown-extensions==10.0.1
+pymdown-extensions==10.1
     # via
     #   mkdocs-material
     #   mkdocstrings

--- a/requirements/examples.txt
+++ b/requirements/examples.txt
@@ -5,19 +5,19 @@
 #
 #    pip-compile-multi
 #
-authlib==1.2.0
+authlib==1.2.1
     # via -r requirements/examples.in
 blinker==1.6.2
     # via flask
 cffi==1.15.1
     # via cryptography
-click==8.1.3
+click==8.1.5
     # via flask
-cryptography==39.0.2
+cryptography==41.0.2
     # via authlib
-flask==2.2.3
+flask==2.3.2
     # via flask-sqlalchemy
-flask-sqlalchemy==3.0.3
+flask-sqlalchemy==3.0.5
     # via -r requirements/examples.in
 greenlet==2.0.2
     # via sqlalchemy
@@ -25,7 +25,7 @@ itsdangerous==2.1.2
     # via flask
 jinja2==3.1.2
     # via flask
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug
@@ -39,14 +39,14 @@ packaging==23.1
     # via marshmallow
 pycparser==2.21
     # via cffi
-sqlalchemy==2.0.16
+sqlalchemy==2.0.19
     # via flask-sqlalchemy
-typing-extensions==4.5.0
+typing-extensions==4.7.1
     # via
     #   marshmallow-dataclass
     #   sqlalchemy
     #   typing-inspect
 typing-inspect==0.9.0
     # via marshmallow-dataclass
-werkzeug==2.2.3
+werkzeug==2.3.6
     # via flask

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -11,9 +11,10 @@ attrs==23.1.0
     # via
     #   jsonschema
     #   pytest
+    #   referencing
 certifi==2023.5.7
     # via requests
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
 coverage[toml]==7.2.7
     # via pytest-cov
@@ -21,29 +22,30 @@ idna==3.4
     # via requests
 iniconfig==2.0.0
     # via pytest
-jsonschema==4.17.3
+jsonschema==4.18.3
     # via
-    #   jsonschema-spec
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-spec==0.1.6
+jsonschema-spec==0.2.3
     # via openapi-spec-validator
+jsonschema-specifications==2023.6.1
+    # via
+    #   jsonschema
+    #   openapi-schema-validator
 lazy-object-proxy==1.9.0
     # via openapi-spec-validator
-openapi-schema-validator==0.4.4
+openapi-schema-validator==0.6.0
     # via openapi-spec-validator
-openapi-spec-validator==0.5.6
+openapi-spec-validator==0.6.0
     # via -r requirements/tests.in
 packaging==23.1
     # via pytest
 pathable==0.4.3
     # via jsonschema-spec
-pluggy==1.0.0
+pluggy==1.2.0
     # via pytest
 py==1.11.0
     # via pytest
-pyrsistent==0.19.3
-    # via jsonschema
 pytest==6.2.5
     # via
     #   -r requirements/tests.in
@@ -52,17 +54,26 @@ pytest-cov==4.1.0
     # via -r requirements/tests.in
 pyyaml==6.0
     # via jsonschema-spec
+referencing==0.29.1
+    # via
+    #   jsonschema
+    #   jsonschema-spec
+    #   jsonschema-specifications
 requests==2.31.0
     # via jsonschema-spec
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
+rpds-py==0.8.10
+    # via
+    #   jsonschema
+    #   referencing
 six==1.16.0
     # via rfc3339-validator
 toml==0.10.2
     # via pytest
 tomli==2.0.1
     # via coverage
-typing-extensions==4.5.0
+typing-extensions==4.7.1
     # via asgiref
 urllib3==2.0.3
     # via requests

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -5,11 +5,11 @@
 #
 #    pip-compile-multi
 #
-mypy==1.3.0
+mypy==1.4.1
     # via -r requirements/typing.in
 mypy-extensions==1.0.0
     # via mypy
 tomli==2.0.1
     # via mypy
-typing-extensions==4.5.0
+typing-extensions==4.7.1
     # via mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,9 +21,10 @@ classifiers =
         Framework :: Flask
         Intended Audience :: Developers
         Programming Language :: Python :: 3 :: Only
-        Programming Language :: Python :: 3.7
         Programming Language :: Python :: 3.8
         Programming Language :: Python :: 3.9
+        Programming Language :: Python :: 3.10
+        Programming Language :: Python :: 3.11
         License :: OSI Approved :: MIT License
         Operating System :: OS Independent
         Topic :: Internet :: WWW/HTTP :: Dynamic Content
@@ -35,7 +36,7 @@ classifiers =
 packages = find:
 package_dir = = src
 include_package_data = true
-python_requires = >= 3.7
+python_requires = >= 3.8
 # Dependencies are in setup.py for GitHub's dependency graph.
 
 [options.packages.find]

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,11 @@ from setuptools import setup
 setup(
     name='APIFlask',
     install_requires=[
-        'flask >= 2.0.0',
+        'flask >= 2.2.0',
         'flask-marshmallow >= 0.12.0',
         'webargs >= 8.3',
         'flask-httpauth >= 4',
-        'apispec >= 4.2.0',
-        'typing-extensions; python_version < "3.8"',
+        'apispec >= 6',
     ],
     tests_require=[
         'openapi-spec-validator',

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -1,14 +1,8 @@
 import inspect
 import json
 import re
-import sys
 import typing as t
 import warnings
-
-# temp fix for https://github.com/django/asgiref/issues/143
-if sys.platform == 'win32' and (3, 8, 0) <= sys.version_info < (3, 9, 0):  # pragma: no cover
-    import asyncio
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # pragma: no cover
 
 from apispec import APISpec
 from apispec import BasePlugin
@@ -20,7 +14,6 @@ from flask import jsonify
 from flask import render_template_string
 from flask import request
 from flask.config import ConfigAttribute
-from flask.wrappers import Response
 
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')
@@ -397,19 +390,6 @@ class APIFlask(APIScaffold, Flask):
                 headers=headers
             )
             return self.error_callback(error)
-
-    # TODO: remove this function when we dropped the Flask 1.x support
-    # the list return values are supported in Flask 2.2
-    def make_response(self, rv) -> Response:
-        """Patch the make_response form Flask to allow returning list as JSON.
-
-        *Version added: 1.1.0*
-        """
-        if isinstance(rv, list):
-            rv = jsonify(rv)
-        elif isinstance(rv, tuple) and isinstance(rv[0], list):
-            rv = (jsonify(rv[0]), *rv[1:])
-        return super().make_response(rv)
 
     @staticmethod
     def _error_handler(
@@ -1197,7 +1177,6 @@ class APIFlask(APIScaffold, Flask):
             for method in ['get', 'post', 'put', 'patch', 'delete']:
                 if method in operations:
                     sorted_operations[method] = operations[method]
-            # TODO: remove the type ignore comment when apispec 5.3.0 released
-            spec.path(path=path, operations=sorted_operations)  # type: ignore
+            spec.path(path=path, operations=sorted_operations)
 
         return spec

--- a/tests/test_decorator_input.py
+++ b/tests/test_decorator_input.py
@@ -125,9 +125,7 @@ def test_input_with_files_location(app, client):
 
     rv = client.get('/openapi.json')
     assert rv.status_code == 200
-    # TODO: Failed validating 'oneOf' in schema
-    # https://github.com/p1c2u/openapi-spec-validator/issues/113
-    # validate_spec(rv.json)
+    validate_spec(rv.json)
     assert 'multipart/form-data' in rv.json['paths']['/']['post']['requestBody']['content']
     assert rv.json['paths']['/']['post']['requestBody'][
         'content']['multipart/form-data']['schema']['$ref'] == '#/components/schemas/Files'
@@ -159,9 +157,7 @@ def test_input_with_form_and_files_location(app, client):
 
     rv = client.get('/openapi.json')
     assert rv.status_code == 200
-    # TODO: Failed validating 'oneOf' in schema
-    # https://github.com/p1c2u/openapi-spec-validator/issues/113
-    # validate_spec(rv.json)
+    validate_spec(rv.json)
     assert 'multipart/form-data' in rv.json['paths']['/']['post']['requestBody']['content']
     assert rv.json['paths']['/']['post']['requestBody'][
         'content']['multipart/form-data']['schema']['$ref'] == '#/components/schemas/FormAndFiles'
@@ -189,9 +185,7 @@ def test_input_with_path_location(app, client):
 
     rv = client.get('/openapi.json')
     assert rv.status_code == 200
-    # TODO: Failed validating 'oneOf' in schema
-    # https://github.com/p1c2u/openapi-spec-validator/issues/113
-    # validate_spec(rv.json)
+    validate_spec(rv.json)
     assert '/{image_type}' in rv.json['paths']
     assert len(rv.json['paths']['/{image_type}']['get']['parameters']) == 1
     assert rv.json['paths']['/{image_type}']['get']['parameters'][0]['in'] == 'path'

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
-    py3{11,10,9,8,7},pypy3{8,7}
-    py310-min
-    py37-dev
+    py3{11,10,9,8}
+    pypy310
     style
     typing
     docs


### PR DESCRIPTION
- Drop Python 3.7 support.
- Update dependencies.
- Remove outdated docs and code.
- Update mkdocs config.