### PR TITLE
Support complete custom response spec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,11 @@ Released: -<br>Codename: Gongqing
   - The `tag` parameter in `@app.doc`.
   - The `role` parameter in `@app.auth_required`.
   - The `redoc_path` parameter in `apiflask.APIFlask` and the `/redoc` path.
+- Support setting a complete response OpenAPI spec throught the `app.doc(responses)`
+  parameter (i.e. `responses={400: {'description': '', 'content': ...}}`)
+  ([issue #327][issue_327]).
 
+[issue_327]: https://github.com/apiflask/apiflask/issues/327
 [issue_427]: https://github.com/apiflask/apiflask/issues/427
 [issue_442]: https://github.com/apiflask/apiflask/issues/442
 [issue_447]: https://github.com/apiflask/apiflask/issues/447

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -824,19 +824,62 @@ def hello():
 As described above, APIFlask will add some responses based on the decorators you added
 on the view function (200, 400, 401, 404). Sometimes you may want to add alternative
 responses the view function will return, then you can use the `@app.doc(responses=...)`
-parameter, it accepts the following values:
-
-- A list of status code int, for example, `[404, 418]`.
-- A dict in a format of `{<STATUS_CODE>: <DESCRIPTION>}`, this will allow you to
-set a custom description for each status, for example,
-`{404: 'Not Found', 418: 'Blah...'}`. If a response with the same status code is
-already exist, the existing description will be overwritten.
+parameter:
 
 ```python
 @app.get('/')
 @app.doc(responses=[204, 404])
 def hello():
     return 'Hello'
+```
+
+The `responses` parameter accepts the following values:
+
+- A list of status code int, for example, `[404, 418]`.
+- A dict in a format of `{<STATUS_CODE>: <DESCRIPTION>}`, this will allow you to
+set a custom description for each status, for example,
+`{404: 'Not Found', 418: 'Blah...'}`. If a response with the same status code is
+already exist, the existing description will be overwritten.
+- A dict in a format of `{<STATUS_CODE>: {RESPONSE}}`, where the `{RESPONSE}` is
+a complete spec dict for the response. For example:
+
+```python
+@app.doc(responses={
+    400: {
+        'description': 'Custom error',
+        'content': {
+            'application/json': {
+                'schema': {
+                    'type': 'object',
+                    'properties': {
+                        'data': {
+                            'type': 'object',
+                            'properties': {
+                                'error_id': {'type': 'integer'},
+                                'message': {'type': 'string'},
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+})
+```
+
+You can also pass a schema class for the `schema`:
+
+```python
+@app.doc(responses={
+    404: {
+        'description': 'Custom error',
+        'content': {
+            'application/json': {
+                'schema': SomeErrorSchema
+            }
+        }
+    }
+})
 ```
 
 

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -80,3 +80,9 @@ class ValidationError(Schema):
 class HTTPError(Schema):
     status_code = String(required=True)
     message = String(required=True)
+
+
+class CustomHTTPError(Schema):
+    status_code = String(required=True)
+    message = String(required=True)
+    custom = String(required=True)


### PR DESCRIPTION
Enhance the `doc` decorator to support passing a complete response spec for the `responses` parameter. For example:

```py
@app.doc(responses={
    404: {
        'description': 'Custom error',
        'content': {
            'application/json': {
                'schema': SomeErrorSchema
            }
        }
    }
})
```

fixes #327

<!--
If needed, ensure each step in the checklist below is complete. If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [ ] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
