### PR TITLE
Generate a better OpenAPI description from docstring

### DIFF
--- a/src/apiflask/openapi.py
+++ b/src/apiflask/openapi.py
@@ -157,7 +157,7 @@ def get_path_description(func: t.Callable) -> str:
         # indent given by the last line
         indent_size = len(docs[-1])
         # use the remain lines of docstring as description
-        return '\n'.join(map(lambda x:x[indent_size:], docs[1:]))
+        return '\n'.join(map(lambda x:x[indent_size:], docs[1:])).strip()
     return ''
 
 

--- a/src/apiflask/openapi.py
+++ b/src/apiflask/openapi.py
@@ -152,12 +152,12 @@ def get_path_summary(func: t.Callable, fallback: t.Optional[str] = None) -> str:
 def get_path_description(func: t.Callable) -> str:
     """Get path description from the docstring of the view function."""
     docs: list = (func.__doc__ or '').split('\n')
-    
+
     if len(docs) > 1:
         # indent given by the last line
         indent_size = len(docs[-1])
         # use the remain lines of docstring as description
-        return '\n'.join(map(lambda x:x[indent_size:], docs[1:])).strip()
+        return '\n'.join(map(lambda x: x[indent_size:], docs[1:])).strip()
     return ''
 
 

--- a/src/apiflask/openapi.py
+++ b/src/apiflask/openapi.py
@@ -151,10 +151,13 @@ def get_path_summary(func: t.Callable, fallback: t.Optional[str] = None) -> str:
 
 def get_path_description(func: t.Callable) -> str:
     """Get path description from the docstring of the view function."""
-    docs = (func.__doc__ or '').strip().split('\n')
+    docs: list = (func.__doc__ or '').split('\n')
+    
     if len(docs) > 1:
+        # indent given by the last line
+        indent_size = len(docs[-1])
         # use the remain lines of docstring as description
-        return '\n'.join(docs[1:]).strip()
+        return '\n'.join(map(lambda x:x[indent_size:], docs[1:]))
     return ''
 
 


### PR DESCRIPTION
_As this PR is a minor one, I'm skipping the issue creation. Please forgive me..._

### Context
If a docstring is well indented (often automatically by black or other) the generated description for OpenAPI will contains indentation, which is not desirable. Markdown will interpret this indentation as code block:

```
        """Summary

        Description line 1

        Description line 2
        """
```
generates
```
Description line 1\n\n        Description line 2
```

with this PR, the generated MD would be
```
Description line 1\n\nDescription line 2
```

Have a nice day :)
Antoine