### PR TITLE
Update typing and documentation for `responses` parameter on `doc` decorator

### DIFF
--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -30,7 +30,7 @@ from .exceptions import _bad_schema_message
 from .helpers import get_reason_phrase
 from .route import route_patch
 from .schemas import Schema
-from .types import ResponseReturnValueType
+from .types import ResponseReturnValueType, ResponsesType
 from .types import ViewFuncType
 from .types import ErrorCallbackType
 from .types import SpecCallbackType
@@ -1061,11 +1061,7 @@ class APIFlask(APIScaffold, Flask):
                     )
 
                 if view_func._spec.get('responses'):
-                    responses: t.Union[
-                        t.List[int],
-                        t.Dict[int, str],
-                        t.Dict[int, t.Dict[str, t.Union[str, t.Dict]]],
-                    ] = view_func._spec.get('responses')
+                    responses: ResponsesType = view_func._spec.get('responses')
                     # turn status_code list to dict {status_code: reason_phrase}
                     if isinstance(responses, list):
                         responses: t.Dict[int, str] = {}  # type: ignore

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -1061,8 +1061,11 @@ class APIFlask(APIScaffold, Flask):
                     )
 
                 if view_func._spec.get('responses'):
-                    responses: t.Union[t.List[int], t.Dict[int, str]] \
-                        = view_func._spec.get('responses')
+                    responses: t.Union[
+                        t.List[int],
+                        t.Dict[int, str],
+                        t.Dict[int, t.Dict[str, t.Union[str, t.Dict]]],
+                    ] = view_func._spec.get('responses')
                     # turn status_code list to dict {status_code: reason_phrase}
                     if isinstance(responses, list):
                         responses: t.Dict[int, str] = {}  # type: ignore

--- a/src/apiflask/scaffold.py
+++ b/src/apiflask/scaffold.py
@@ -515,7 +515,9 @@ class APIScaffold:
         summary: t.Optional[str] = None,
         description: t.Optional[str] = None,
         tags: t.Optional[t.List[str]] = None,
-        responses: t.Optional[t.Union[t.List[int], t.Dict[int, str]]] = None,
+        responses: t.Optional[
+            t.Union[t.List[int], t.Dict[int, str], t.Dict[int, t.Dict[str, t.Union[str, t.Dict]]]]
+        ] = None,
         deprecated: t.Optional[bool] = None,
         hide: t.Optional[bool] = None,
         operation_id: t.Optional[str] = None,
@@ -553,10 +555,11 @@ class APIScaffold:
                 line of the docstring will be used.
             tags: A list of tag names of this endpoint, map the tags you passed in the `app.tags`
                 attribute. If `app.tags` is not set, the blueprint name will be used as tag name.
-            responses: The other responses for this view function, accepts a dict in a format
-                of `{404: 'Not Found'}` or a list of status code (`[404, 418]`). If pass a dict,
-                and a response with the same status code is already exist, the existing
-                description will be overwritten.
+            responses: The other responses for this view function, accepts a list of status codes
+                (`[404, 418]`) or a dict in a format of either `{404: 'Not Found'}` or
+                `{404: {'description': 'Not Found', 'content': {'application/json':
+                {'schema': FooSchema}}}}`. If a dict is passed and a response with the same status
+                code is already present, the existing data will be overwritten.
             deprecated: Flag this endpoint as deprecated in API docs.
             hide: Hide this endpoint in API docs.
             operation_id: The `operationId` of this endpoint. Set config `AUTO_OPERATION_ID` to
@@ -570,6 +573,7 @@ class APIScaffold:
         *Version changed: 2.0.0*
 
         - Remove the deprecated `tag` parameter.
+        - Expand `responses` to support additional structure and parameters.
 
         *Version changed: 1.0*
 

--- a/src/apiflask/scaffold.py
+++ b/src/apiflask/scaffold.py
@@ -19,6 +19,7 @@ from .types import HTTPAuthType
 from .types import OpenAPISchemaType
 from .types import RequestType
 from .types import ResponseReturnValueType
+from .types import ResponsesType
 from .types import SchemaType
 from .views import MethodView
 
@@ -515,9 +516,7 @@ class APIScaffold:
         summary: t.Optional[str] = None,
         description: t.Optional[str] = None,
         tags: t.Optional[t.List[str]] = None,
-        responses: t.Optional[
-            t.Union[t.List[int], t.Dict[int, str], t.Dict[int, t.Dict[str, t.Union[str, t.Dict]]]]
-        ] = None,
+        responses: t.Optional[ResponsesType] = None,
         deprecated: t.Optional[bool] = None,
         hide: t.Optional[bool] = None,
         operation_id: t.Optional[str] = None,

--- a/src/apiflask/types.py
+++ b/src/apiflask/types.py
@@ -59,6 +59,10 @@ TagsType = t.Union[t.List[str], t.List[t.Dict[str, t.Any]]]
 ViewClassType = t.Type['View']
 ViewFuncOrClassType = t.Union[t.Callable, ViewClassType]
 
+ResponseObjectType = t.Dict[str, t.Union[str, t.Dict[str, t.Dict[str, t.Any]]]]
+ResponsesObjectType = t.Dict[t.Union[int, str], ResponseObjectType]
+ResponsesType = t.Union[t.List[int], t.Dict[int, str], ResponsesObjectType]
+
 RouteCallableType = t.Union[
     t.Callable[..., ResponseReturnValueType],
     t.Callable[..., t.Awaitable[ResponseReturnValueType]],


### PR DESCRIPTION
Update the typing and documentation on the `responses` parameter of the `doc` decorator to match the implementation changes introduced in version 2.0.0 via #458.

Fixes #466.

I'm not sure why mypy isn't complaining about the type mismatch, but I think the parameter typing merits expansion after the 2.0.0 changes. I reworded the documentation a bit but I'm open to feedback or adjustments on it.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [ ] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.

