### PR TITLE
Allow adding multiple media types for a response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 Released: -
 
+- Allow adding multiple media types for a response ([issue #494][issue_494])
+
+[issue_494]: https://github.com/apiflask/apiflask/issues/494
+
 
 ## Version 2.0.2
 

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -717,7 +717,7 @@ def new_pet():
 
 ## Request and response content type / media type
 
-For request, the content type is set automically based on the input location:
+For request, the content type is set automatically based on the input location:
 
 - `json`: `application/json`
 - `form`: `application/x-www-form-urlencoded`
@@ -881,6 +881,48 @@ You can also pass a schema class for the `schema`:
     }
 })
 ```
+
+
+### Multiple media types for a response
+
+You can add additional media types for a response and these will be added to
+the OpenAPI document. This allows you to describe situations where you may
+return a different representation of a resource, perhaps by performing
+[content negotiation][content_negotiation] based on some parameter of the
+request. This is done by supplying custom `responses` and including
+additional media types in the `content` section of each response, as
+in the following:
+
+```python
+@app.get("/pets/<int:pet_id>")
+@app.input(Accept, location="headers")
+@app.output(PetOut)
+@app.doc(responses={
+    200: {
+        'description': 'Return the resource in either JSON or HTML',
+        'content': {
+            'text/html': {}
+        }
+    }
+})
+def get_pet(pet_id, headers_data):
+    pet = pets[pet_id]
+    if "html" in headers_data.get('accept'):
+        result = render_template('pets/pet-detail.j2.html', pet=pet)
+    else:
+        result = pet
+    return result
+```
+
+The previous snippet shows how you could inspect the request's `Accept`
+header and then return either an HTML representation or a JSON representation
+of the same resource.
+
+Note that APIFlask thus allows you to complement the default `application/json`
+media type, which is automatically added by APIFlask for views that include the
+`@app.output` decorator with additional media types.
+
+[content_negotiation]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation
 
 
 ### Mark an operation as `deprecated`

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -1086,7 +1086,11 @@ class APIFlask(APIScaffold, Flask):
                         status_code: str = str(status_code)  # type: ignore
                         # custom complete response spec
                         if isinstance(value, dict):
-                            operation['responses'][status_code] = value
+                            existing_response = operation['responses'].setdefault(status_code, {})
+                            existing_response_content = existing_response.setdefault('content', {})
+                            existing_response_content.update(value.get('content', {}))
+                            if (new_description := value.get('description')) is not None:
+                                existing_response['description'] = new_description
                             continue
                         else:
                             description = value


### PR DESCRIPTION
This PR modifies the code that handles `@app.doc(responses=...)`. The proposed implementation deals with cases where
a `dict` is passed.

The previous behavior assumed the passed dict would be used as the OpenAPI definition of the view's responses. This proposed implementation instead merges the contents of the passed dict taking into account the `content` key of each
status code. This is done in order to preserve whatever information might have already been automatically generated in
previous steps, namely what had been added while processing `app.output()`.

This means that with the current PR, APIFlask would preserve a view's main response media type, while also allowing
the addition of other, secondary media types, thus addressing the contents of issue #494

fixes #494

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring. - IMO this doesn't seem relevant for the current PR
- [x] Run `pytest` and `tox`, no tests failed.
