### PR TITLE
fix typo: missing parameter `ma_plugin`

### DIFF
--- a/src/apiflask/openapi.py
+++ b/src/apiflask/openapi.py
@@ -177,6 +177,7 @@ def add_response(
     *Version changed: 2.0.3*
 
     - Add parameter `headers_schema`.
+    - Add parameter `ma_plugin`.
 
     *Version changed: 1.3.0*
 


### PR DESCRIPTION
Sorry! I missed an added parameter [`ma_plugin`](https://github.com/apiflask/apiflask/blob/870ee6b0f264687e7ef2946c7af8d5976ea8107b/src/apiflask/openapi.py#L173) in [`add_response()`](https://github.com/apiflask/apiflask/blob/870ee6b0f264687e7ef2946c7af8d5976ea8107b/src/apiflask/openapi.py#L163C5-L163C17).
