### PR TITLE
Remove override of set_class in Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ APIFlask accepts marshmallow schema as data schema, uses webargs to validate the
 
 You can build marshmallow schemas just like before, but APIFlask also exposes some marshmallow APIs for convenience:
 
-- `apiflask.Schema`: The base marshmallow schema class. Notice it sets the `set_class` to `OrderedSet` by default.
+- `apiflask.Schema`: The base marshmallow schema class.
 - `apiflask.fields`: The marshmallow fields, contain the fields from both marshmallow and Flask-Marshmallow. Beware that the aliases (`Url`, `Str`, `Int`, `Bool`, etc.) were removed.
 - `apiflask.validators`: The marshmallow validators.
 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     install_requires=[
         'flask >= 2',
         'flask-marshmallow >= 0.12.0',
+        'marshmallow >= 3.20',
         'webargs >= 8.3',
         'flask-httpauth >= 4',
         'apispec >= 6',

--- a/src/apiflask/schemas.py
+++ b/src/apiflask/schemas.py
@@ -3,7 +3,6 @@ import typing as t
 from marshmallow import Schema as BaseSchema
 from marshmallow.fields import Integer
 from marshmallow.fields import URL
-from marshmallow.orderedset import OrderedSet
 
 
 # schema for the detail object of validation error response
@@ -52,16 +51,12 @@ http_error_schema: t.Dict[str, t.Any] = {
 
 
 class Schema(BaseSchema):
-    """A base schema for all schemas.
-
-    The different between marshmallow's `Schema` and APIFlask's `Schema` is that the latter
-    sets `set_class` to `OrderedSet` by default.
+    """A base schema for all schemas. Equivalent to `marshmallow.Schema`.
 
     *Version Added: 1.2.0*
     """
-    # use ordered set to keep the order of fields
-    # can be removed when https://github.com/marshmallow-code/marshmallow/pull/1896 is merged
-    set_class = OrderedSet
+
+    pass
 
 
 class EmptySchema(Schema):


### PR DESCRIPTION
As of marshmallow 3.20.0 (released 2023-07-20), OrderedSet is the default set_class.

