### PR TITLE
perf: optimize `get_filestorage_size`

### DIFF
--- a/src/apiflask/helpers.py
+++ b/src/apiflask/helpers.py
@@ -119,8 +119,7 @@ def get_filestorage_size(file: FileStorage) -> int:
 
     *Version added: 2.1.0*
     """
-    size = len(file.read())
-    file.stream.seek(0)
+    size: int = file.stream.getbuffer().nbytes  # type: ignore
     return size
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -65,8 +65,14 @@ def test_pagination_builder(app, client):
 
 
 def test_get_filestorage_size():
+    rv = get_filestorage_size(FileStorage(io.BytesIO(b''.ljust(0))))
+    assert rv == 0
+    rv = get_filestorage_size(FileStorage(io.BytesIO(b''.ljust(123))))
+    assert rv == 123
     rv = get_filestorage_size(FileStorage(io.BytesIO(b''.ljust(1024))))
     assert rv == 1024
+    rv = get_filestorage_size(FileStorage(io.BytesIO(b''.ljust(1234))))
+    assert rv == 1234
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The old `get_filestorage_size` get the size by `len(file.read())` which triggers a read operation and consumes additional memory.
Old version:
```python
def get_filestorage_size(file: FileStorage) -> int:
    size = len(file.read())
    file.stream.seek(0)
    return size
```

The new `get_filestorage_size` get the size by `file.stream.getbuffer().nbytes` which returns the number of bytes of the data directly without any extra overhead.
New version:
```python
def get_filestorage_size(file: FileStorage) -> int:
    size: int = file.stream.getbuffer().nbytes  # type: ignore
    return size
```