### PR TITLE
Add support for a --quiet flag to the flask spec command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,10 @@
 
 Released: -
 - Reuse the File, Config field, and file-related validators from flask-marshmallow ([issue #540][issue_540]).
+- Add support for a `--quiet` option to the `flask spec` command ([issue #548][issue_548]).
 
 [issue_540]: https://github.com/apiflask/apiflask/issues/540
+[issue_548]: https://github.com/apiflask/apiflask/issues/548
 
 
 ## Version 2.1.0

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -246,6 +246,19 @@ $ flask spec
 ```
 
 
+### Suppress the output
+
+!!! warning "Version >= 2.1.1"
+
+    This feature was added in the [version 2.1.1](/changelog/#version-211).
+
+If you wish to write the spec to a local file without also printing to stdout, you can specify the `--quiet/-q` option:
+
+```
+$ flask spec --output openapi.json --quiet
+```
+
+
 ## Keep the local spec in sync
 
 !!! warning "Version >= 0.7.0"

--- a/src/apiflask/commands.py
+++ b/src/apiflask/commands.py
@@ -24,8 +24,15 @@ from flask.cli import with_appcontext
     type=int,
     help='The indentation for JSON spec, defaults to LOCAL_SPEC_JSON_INDENT config.'
 )
+@click.option(
+    '--quiet',
+    '-q',
+    type=bool,
+    is_flag=True,
+    help='A flag to suppress printing output to stdout.'
+)
 @with_appcontext
-def spec_command(format, output, indent):
+def spec_command(format, output, indent, quiet):
     """Output the OpenAPI spec to stdout or a file.
 
     Check out the docs for the detailed usage:
@@ -43,7 +50,8 @@ def spec_command(format, output, indent):
         spec = json.dumps(spec, indent=json_indent)
 
     # output to stdout
-    click.echo(spec)
+    if not quiet:
+        click.echo(spec)
 
     # output to local file
     if output_path:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -71,3 +71,8 @@ def test_flask_spec_indent(cli_runner, indent, tmp_path):
     else:
         assert f'{{\n{" " * indent}"info": {{' in stdout_result.output
         assert f'{{\n{" " * indent}"info": {{' in file_result.output
+
+
+def test_flask_spec_quiet(app, cli_runner):
+    result = cli_runner.invoke(spec_command, ['--quiet'])
+    assert result.output == ''


### PR DESCRIPTION
Added support for a `--quiet/-q` option to the `flask spec` command, so that output can be written to a file without also writing to stdout.

Fixes #548.


Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
