### PR TITLE
doc: correct the OpenAPI example links in the documentation

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -1148,5 +1148,5 @@ def update_spec(spec):
     return spec
 ```
 
-Check out [the example application](https://github.com/apiflask/apiflask/tree/main/examples/openapi/app.py)
+Check out [the example application](https://github.com/apiflask/apiflask/tree/main/examples/openapi)
 for OpenAPI support, see [the examples page](/examples) for running the example application.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
 - Class-based view example: [/examples/cbv/app.py][_cbv]
 - ORM example (with Flask-SQLAlchemy): [/examples/orm/app.py][_orm]
 - Pagination example (with Flask-SQLAlchemy): [/examples/pagination/app.py][_pagination]
-- OpenAPI example: [/examples/openapi/app.py][_openapi]
+- OpenAPI example: [/examples/openapi][_openapi]
 - Base response example: [/examples/base_response/app.py][_base_response]
 - Token auth example: [/examples/auth/token_auth/app.py][_token_auth]
 - Basic auth example: [/examples/auth/basic_auth/app.py][_basic_auth]
@@ -15,7 +15,7 @@
 [_cbv]: https://github.com/apiflask/apiflask/tree/main/examples/cbv/app.py
 [_orm]: https://github.com/apiflask/apiflask/tree/main/examples/orm/app.py
 [_pagination]: https://github.com/apiflask/apiflask/tree/main/examples/pagination/app.py
-[_openapi]: https://github.com/apiflask/apiflask/tree/main/examples/openapi/app.py
+[_openapi]: https://github.com/apiflask/apiflask/tree/main/examples/openapi
 [_base_response]: https://github.com/apiflask/apiflask/tree/main/examples/base_response/app.py
 [_token_auth]: https://github.com/apiflask/apiflask/tree/main/examples/auth/token_auth/app.py
 [_basic_auth]: https://github.com/apiflask/apiflask/tree/main/examples/auth/basic_auth/app.py


### PR DESCRIPTION
Updated the README.md in the /examples directory and the openapi.md in the /docs directory  correctly point to the OpenAPI example locations.

 

