### PR TITLE
Use postponed evaluation of annotations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 ## Version 2.1.4
 
-Released: -
+Unreleased
+
+- Use postponed evaluation of annotations ([pr #585][pr_585]).
+
+[pr_585]: https://github.com/apiflask/apiflask/pull/585
 
 
 ## Version 2.1.3

--- a/src/apiflask/blueprint.py
+++ b/src/apiflask/blueprint.py
@@ -1,4 +1,4 @@
-import typing as t
+from __future__ import annotations
 
 from flask import Blueprint
 
@@ -30,16 +30,16 @@ class APIBlueprint(APIScaffold, Blueprint):
         self,
         name: str,
         import_name: str,
-        tag: t.Optional[t.Union[str, dict]] = None,
+        tag: str | dict | None = None,
         enable_openapi: bool = True,
-        static_folder: t.Optional[str] = None,
-        static_url_path: t.Optional[str] = None,
-        template_folder: t.Optional[str] = None,
-        url_prefix: t.Optional[str] = None,
-        subdomain: t.Optional[str] = None,
-        url_defaults: t.Optional[dict] = None,
-        root_path: t.Optional[str] = None,
-        cli_group: t.Union[t.Optional[str]] = _sentinel  # type: ignore
+        static_folder: str | None = None,
+        static_url_path: str | None = None,
+        template_folder: str | None = None,
+        url_prefix: str | None = None,
+        subdomain: str | None = None,
+        url_defaults: dict | None = None,
+        root_path: str | None = None,
+        cli_group: str | None = _sentinel  # type: ignore
     ) -> None:
         """Make a blueprint instance.
 

--- a/src/apiflask/exceptions.py
+++ b/src/apiflask/exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 
 from werkzeug.exceptions import default_exceptions
@@ -27,18 +29,18 @@ class HTTPError(Exception):
     ```
     """
     status_code: int = 500
-    message: t.Optional[str] = None
+    message: str | None = None
     detail: t.Any = {}
     headers: ResponseHeaderType = {}
     extra_data: t.Mapping[str, t.Any] = {}
 
     def __init__(
         self,
-        status_code: t.Optional[int] = None,
-        message: t.Optional[str] = None,
-        detail: t.Optional[t.Any] = None,
-        headers: t.Optional[ResponseHeaderType] = None,
-        extra_data: t.Optional[t.Mapping[str, t.Any]] = None
+        status_code: int | None = None,
+        message: str | None = None,
+        detail: t.Any | None = None,
+        headers: ResponseHeaderType | None = None,
+        extra_data: t.Mapping[str, t.Any] | None = None
     ) -> None:
         """Initialize the error response.
 
@@ -97,10 +99,10 @@ class _ValidationError(HTTPError):
 
 def abort(
     status_code: int,
-    message: t.Optional[str] = None,
-    detail: t.Optional[t.Any] = None,
-    headers: t.Optional[ResponseHeaderType] = None,
-    extra_data: t.Optional[dict] = None
+    message: str | None = None,
+    detail: t.Any | None = None,
+    headers: ResponseHeaderType | None = None,
+    extra_data: dict | None = None
 ) -> t.NoReturn:
     """A function to raise HTTPError exception.
 

--- a/src/apiflask/helpers.py
+++ b/src/apiflask/helpers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 
 from flask import request
@@ -84,7 +86,7 @@ def pagination_builder(pagination: PaginationType, **kwargs: t.Any) -> dict:
 
     *Version Added: 0.6.0*
     """
-    endpoint: t.Optional[str] = request.endpoint
+    endpoint: str | None = request.endpoint
     per_page: int = pagination.per_page
 
     def get_page_url(page: int) -> str:

--- a/src/apiflask/openapi.py
+++ b/src/apiflask/openapi.py
@@ -10,7 +10,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
     from .blueprint import APIBlueprint
 
 
-default_bypassed_endpoints: t.List[str] = [
+default_bypassed_endpoints: list[str] = [
     'static',
     'openapi.spec',
     'openapi.docs',
@@ -34,9 +34,9 @@ default_response = {
 def get_tag(
     blueprint: APIBlueprint,
     blueprint_name: str
-) -> t.Dict[str, t.Any]:
+) -> dict[str, t.Any]:
     """Get tag from blueprint object."""
-    tag: t.Dict[str, t.Any]
+    tag: dict[str, t.Any]
     if blueprint.tag is not None:
         if isinstance(blueprint.tag, dict):
             tag = blueprint.tag
@@ -50,9 +50,9 @@ def get_tag(
 def get_operation_tags(
     blueprint: APIBlueprint,
     blueprint_name: str
-) -> t.List[str]:
+) -> list[str]:
     """Get operation tag from blueprint object."""
-    tags: t.List[str]
+    tags: list[str]
     if blueprint.tag is not None:
         if isinstance(blueprint.tag, dict):
             tags = [blueprint.tag['name']]
@@ -65,7 +65,7 @@ def get_operation_tags(
 
 def get_auth_name(
     auth: HTTPAuthType,
-    auth_names: t.List[str]
+    auth_names: list[str]
 ) -> str:
     """Get auth name from auth object."""
     name: str = ''
@@ -92,9 +92,9 @@ def get_auth_name(
     return name
 
 
-def get_security_scheme(auth: HTTPAuthType) -> t.Dict[str, t.Any]:
+def get_security_scheme(auth: HTTPAuthType) -> dict[str, t.Any]:
     """Get security scheme from auth object."""
-    security_scheme: t.Dict[str, t.Any]
+    security_scheme: dict[str, t.Any]
     if isinstance(auth, HTTPTokenAuth):
         if auth.scheme.lower() == 'bearer' and auth.header is None:
             security_scheme = {
@@ -116,12 +116,12 @@ def get_security_scheme(auth: HTTPAuthType) -> t.Dict[str, t.Any]:
 
 
 def get_security_and_security_schemes(
-    auth_names: t.List[str],
-    auth_schemes: t.List[HTTPAuthType]
-) -> t.Tuple[t.Dict[HTTPAuthType, str], t.Dict[str, t.Dict[str, str]]]:
+    auth_names: list[str],
+    auth_schemes: list[HTTPAuthType]
+) -> tuple[dict[HTTPAuthType, str], dict[str, dict[str, str]]]:
     """Make security and security schemes from given auth names and schemes."""
-    security: t.Dict[HTTPAuthType, str] = {}
-    security_schemes: t.Dict[str, t.Dict[str, str]] = {}
+    security: dict[HTTPAuthType, str] = {}
+    security_schemes: dict[str, dict[str, str]] = {}
     for name, auth in zip(auth_names, auth_schemes):  # noqa: B905
         security[auth] = name
         security_schemes[name] = get_security_scheme(auth)
@@ -130,7 +130,7 @@ def get_security_and_security_schemes(
     return security, security_schemes
 
 
-def get_path_summary(func: t.Callable, fallback: t.Optional[str] = None) -> str:
+def get_path_summary(func: t.Callable, fallback: str | None = None) -> str:
     """Get path summary from the name or docstring of the view function."""
     summary: str
     docs: list = (func.__doc__ or '').strip().split('\n')
@@ -152,9 +152,9 @@ def get_path_description(func: t.Callable) -> str:
     return ''
 
 
-def get_argument(argument_type: str, argument_name: str) -> t.Dict[str, t.Any]:
+def get_argument(argument_type: str, argument_name: str) -> dict[str, t.Any]:
     """Make argument from given type and name."""
-    argument: t.Dict[str, t.Any] = {
+    argument: dict[str, t.Any] = {
         'in': 'path',
         'name': argument_name,
     }

--- a/src/apiflask/route.py
+++ b/src/apiflask/route.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 
 from .openapi import get_path_description
@@ -63,9 +65,9 @@ def route_patch(cls):
     def add_url_rule(
         self,
         rule: str,
-        endpoint: t.Optional[str] = None,
-        view_func: t.Optional[ViewFuncOrClassType] = None,
-        provide_automatic_options: t.Optional[bool] = None,
+        endpoint: str | None = None,
+        view_func: ViewFuncOrClassType | None = None,
+        provide_automatic_options: bool | None = None,
         **options: t.Any,
     ):
         """Record the spec for view classes before calling the actual `add_url_rule` method.

--- a/src/apiflask/scaffold.py
+++ b/src/apiflask/scaffold.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 from collections.abc import Mapping as ABCMapping
 from functools import wraps
@@ -93,8 +95,8 @@ def _ensure_sync(f):
 
 def _generate_schema_from_mapping(
     schema: DictSchemaType,
-    schema_name: t.Optional[str]
-) -> t.Type[Schema]:
+    schema_name: str | None
+) -> type[Schema]:
     if schema_name is None:
         schema_name = 'GeneratedSchema'
     return Schema.from_dict(schema, name=schema_name)()  # type: ignore
@@ -145,8 +147,8 @@ class APIScaffold:
     def auth_required(
         self,
         auth: HTTPAuthType,
-        roles: t.Optional[list] = None,
-        optional: t.Optional[str] = None
+        roles: list | None = None,
+        optional: str | None = None
     ) -> t.Callable[[DecoratedType], DecoratedType]:
         """Protect a view with provided authentication settings.
 
@@ -204,10 +206,10 @@ class APIScaffold:
         self,
         schema: SchemaType,
         location: str = 'json',
-        arg_name: t.Optional[str] = None,
-        schema_name: t.Optional[str] = None,
-        example: t.Optional[t.Any] = None,
-        examples: t.Optional[t.Dict[str, t.Any]] = None,
+        arg_name: str | None = None,
+        schema_name: str | None = None,
+        example: t.Any | None = None,
+        examples: dict[str, t.Any] | None = None,
         **kwargs: t.Any
     ) -> t.Callable[[DecoratedType], DecoratedType]:
         """Add input settings for view functions.
@@ -333,13 +335,13 @@ class APIScaffold:
         self,
         schema: SchemaType,
         status_code: int = 200,
-        description: t.Optional[str] = None,
-        schema_name: t.Optional[str] = None,
-        example: t.Optional[t.Any] = None,
-        examples: t.Optional[t.Dict[str, t.Any]] = None,
-        links: t.Optional[t.Dict[str, t.Any]] = None,
-        content_type: t.Optional[str] = 'application/json',
-        headers: t.Optional[SchemaType] = None,
+        description: str | None = None,
+        schema_name: str | None = None,
+        example: t.Any | None = None,
+        examples: dict[str, t.Any] | None = None,
+        links: dict[str, t.Any] | None = None,
+        content_type: str | None = 'application/json',
+        headers: SchemaType | None = None,
     ) -> t.Callable[[DecoratedType], DecoratedType]:
         """Add output settings for view functions.
 
@@ -531,14 +533,14 @@ class APIScaffold:
 
     def doc(
         self,
-        summary: t.Optional[str] = None,
-        description: t.Optional[str] = None,
-        tags: t.Optional[t.List[str]] = None,
-        responses: t.Optional[ResponsesType] = None,
-        deprecated: t.Optional[bool] = None,
-        hide: t.Optional[bool] = None,
-        operation_id: t.Optional[str] = None,
-        security: t.Optional[t.Union[str, t.List[t.Union[str, t.Dict[str, list]]]]] = None,
+        summary: str | None = None,
+        description: str | None = None,
+        tags: list[str] | None = None,
+        responses: ResponsesType | None = None,
+        deprecated: bool | None = None,
+        hide: bool | None = None,
+        operation_id: str | None = None,
+        security: str | list[str | dict[str, list]] | None = None,
     ) -> t.Callable[[DecoratedType], DecoratedType]:
         """Set up the OpenAPI Spec for view functions.
 

--- a/src/apiflask/schemas.py
+++ b/src/apiflask/schemas.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 
 from marshmallow import Schema as BaseSchema
@@ -6,7 +8,7 @@ from marshmallow.fields import URL
 
 
 # schema for the detail object of validation error response
-validation_error_detail_schema: t.Dict[str, t.Any] = {
+validation_error_detail_schema: dict[str, t.Any] = {
     'type': 'object',
     'properties': {
         '<location>': {
@@ -25,7 +27,7 @@ validation_error_detail_schema: t.Dict[str, t.Any] = {
 
 
 # schema for validation error response
-validation_error_schema: t.Dict[str, t.Any] = {
+validation_error_schema: dict[str, t.Any] = {
     'properties': {
         'detail': validation_error_detail_schema,
         'message': {
@@ -37,7 +39,7 @@ validation_error_schema: t.Dict[str, t.Any] = {
 
 
 # schema for generic error response
-http_error_schema: t.Dict[str, t.Any] = {
+http_error_schema: dict[str, t.Any] = {
     'properties': {
         'detail': {
             'type': 'object'

--- a/src/apiflask/security.py
+++ b/src/apiflask/security.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 
 from flask import current_app
@@ -15,15 +17,15 @@ class _AuthBase:
 
     def __init__(
         self,
-        description: t.Optional[str] = None,
-        security_scheme_name: t.Optional[str] = None,
+        description: str | None = None,
+        security_scheme_name: str | None = None,
     ) -> None:
         self.description = description
         self.security_scheme_name = security_scheme_name
         self.error_handler(self._auth_error_handler)  # type: ignore
 
     @property
-    def current_user(self) -> t.Union[None, t.Any]:
+    def current_user(self) -> None | t.Any:
         return g.get('flask_httpauth_user', None)
 
     @staticmethod
@@ -102,9 +104,9 @@ class HTTPBasicAuth(_AuthBase, BaseHTTPBasicAuth):
     def __init__(
         self,
         scheme: str = 'Basic',
-        realm: t.Optional[str] = None,
-        description: t.Optional[str] = None,
-        security_scheme_name: t.Optional[str] = None,
+        realm: str | None = None,
+        description: str | None = None,
+        security_scheme_name: str | None = None,
     ) -> None:
         """Initialize an `HTTPBasicAuth` object.
 
@@ -140,10 +142,10 @@ class HTTPTokenAuth(_AuthBase, BaseHTTPTokenAuth):
     def __init__(
         self,
         scheme: str = 'Bearer',
-        realm: t.Optional[str] = None,
-        header: t.Optional[str] = None,
-        description: t.Optional[str] = None,
-        security_scheme_name: t.Optional[str] = None,
+        realm: str | None = None,
+        header: str | None = None,
+        description: str | None = None,
+        security_scheme_name: str | None = None,
     ) -> None:
         """Initialize a `HTTPTokenAuth` object.
 

--- a/src/apiflask/settings.py
+++ b/src/apiflask/settings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 
 from .schemas import http_error_schema
@@ -8,26 +10,26 @@ from .types import TagsType
 
 # OpenAPI fields
 OPENAPI_VERSION: str = '3.0.3'
-SERVERS: t.Optional[t.List[t.Dict[str, str]]] = None
-TAGS: t.Optional[TagsType] = None
-EXTERNAL_DOCS: t.Optional[t.Dict[str, str]] = None
-INFO: t.Optional[t.Dict[str, t.Union[str, dict]]] = None
-DESCRIPTION: t.Optional[str] = None
-TERMS_OF_SERVICE: t.Optional[str] = None
-CONTACT: t.Optional[t.Dict[str, str]] = None
-LICENSE: t.Optional[t.Dict[str, str]] = None
-SECURITY_SCHEMES: t.Optional[t.Dict[str, t.Any]] = None
+SERVERS: list[dict[str, str]] | None = None
+TAGS: TagsType | None = None
+EXTERNAL_DOCS: dict[str, str] | None = None
+INFO: dict[str, str | dict] | None = None
+DESCRIPTION: str | None = None
+TERMS_OF_SERVICE: str | None = None
+CONTACT: dict[str, str] | None = None
+LICENSE: dict[str, str] | None = None
+SECURITY_SCHEMES: dict[str, t.Any] | None = None
 # OpenAPI spec
 SPEC_FORMAT: str = 'json'
 YAML_SPEC_MIMETYPE: str = 'text/vnd.yaml'
 JSON_SPEC_MIMETYPE: str = 'application/json'
-LOCAL_SPEC_PATH: t.Optional[str] = None
+LOCAL_SPEC_PATH: str | None = None
 LOCAL_SPEC_JSON_INDENT: int = 2
-SYNC_LOCAL_SPEC: t.Optional[bool] = None
+SYNC_LOCAL_SPEC: bool | None = None
 SPEC_PROCESSOR_PASS_OBJECT: bool = False
-SPEC_DECORATORS: t.Optional[t.List[t.Callable]] = None
-DOCS_DECORATORS: t.Optional[t.List[t.Callable]] = None
-SWAGGER_UI_OAUTH_REDIRECT_DECORATORS: t.Optional[t.List[t.Callable]] = None
+SPEC_DECORATORS: list[t.Callable] | None = None
+DOCS_DECORATORS: list[t.Callable] | None = None
+SWAGGER_UI_OAUTH_REDIRECT_DECORATORS: list[t.Callable] | None = None
 # Automation behavior control
 AUTO_TAGS: bool = True
 AUTO_SERVERS: bool = True
@@ -47,31 +49,31 @@ VALIDATION_ERROR_STATUS_CODE: int = 422
 AUTH_ERROR_STATUS_CODE: int = 401
 VALIDATION_ERROR_SCHEMA: OpenAPISchemaType = validation_error_schema
 HTTP_ERROR_SCHEMA: OpenAPISchemaType = http_error_schema
-BASE_RESPONSE_SCHEMA: t.Optional[OpenAPISchemaType] = None
+BASE_RESPONSE_SCHEMA: OpenAPISchemaType | None = None
 BASE_RESPONSE_DATA_KEY: str = 'data'
 # API docs
 DOCS_FAVICON: str = 'https://apiflask.com/_assets/favicon.png'
 REDOC_USE_GOOGLE_FONT: bool = True
 REDOC_STANDALONE_JS: str = 'https://cdn.redoc.ly/redoc/latest/bundles/\
 redoc.standalone.js'  # TODO: rename to REDOC_JS
-REDOC_CONFIG: t.Optional[dict] = None
+REDOC_CONFIG: dict | None = None
 SWAGGER_UI_CSS: str = 'https://unpkg.com/swagger-ui-dist/swagger-ui.css'
 SWAGGER_UI_BUNDLE_JS: str = 'https://unpkg.com/swagger-ui-dist/\
 swagger-ui-bundle.js'  # TODO: rename to SWAGGER_UI_JS
 SWAGGER_UI_STANDALONE_PRESET_JS: str = 'https://unpkg.com/swagger-ui-dist/\
 swagger-ui-standalone-preset.js'  # TODO: rename to SWAGGER_UI_STANDALONE_JS
 SWAGGER_UI_LAYOUT: str = 'BaseLayout'
-SWAGGER_UI_CONFIG: t.Optional[dict] = None
-SWAGGER_UI_OAUTH_CONFIG: t.Optional[dict] = None
+SWAGGER_UI_CONFIG: dict | None = None
+SWAGGER_UI_OAUTH_CONFIG: dict | None = None
 ELEMENTS_JS: str = 'https://unpkg.com/@stoplight/elements/web-components.min.js'
 ELEMENTS_CSS: str = 'https://unpkg.com/@stoplight/elements/styles.min.css'
 ELEMENTS_LAYOUT: str = 'sidebar'
-ELEMENTS_CONFIG: t.Optional[dict] = None
+ELEMENTS_CONFIG: dict | None = None
 RAPIDOC_JS: str = 'https://unpkg.com/rapidoc/dist/rapidoc-min.js'
 RAPIDOC_THEME: str = 'light'
-RAPIDOC_CONFIG: t.Optional[dict] = None
+RAPIDOC_CONFIG: dict | None = None
 RAPIPDF_JS: str = 'https://unpkg.com/rapipdf/dist/rapipdf-min.js'
-RAPIPDF_CONFIG: t.Optional[dict] = None
+RAPIPDF_CONFIG: dict | None = None
 
 # Version changed: 1.2.0
 # Change VALIDATION_ERROR_STATUS_CODE from 400 to 422.

--- a/src/apiflask/types.py
+++ b/src/apiflask/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 from typing import Protocol
 


### PR DESCRIPTION
Add `from __future__ import annotations` to every file that may be annotated. Replace the vast majority of old `Union`, `Optional`, and types with their modern equivalent syntax.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [ ] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
