### PR TITLE
docs: Fix broken doc link regarding flask migrations

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -14,7 +14,9 @@ Welcome to APIFlask's documentation!
 Go through the following chapters to learn how to use APIFlask:
 
 - **[Introduction](/)**: A general introduction for APIFlask.
-- **[Migrating from Flask](/migrating)**: Migratioon guide and notes.
+- **[Migrating from Flask](../migrations/flask)**: Guide to migrate from Flask.
+- **[Migrating from Flask-RESTPlus/Flask-RESTX](../migrations/flask-restplus)**: Guide to migrate from
+  Flask-RESTPlus/Flask-RESTX.
 - **[Basic Usage](/usage)**: Get started with APIFlask.
 - **[Request Handling](/request)**: The detailed introduction of the `@app.input` decorator.
 - **[Response Formatting](/response)**:  The detailed introduction of the `@app.output` decorator.


### PR DESCRIPTION
This PR addresses a 404 error when clicking the `Migrating from flask` option in the [documentation index](https://apiflask.com/docs/) page. Here's a screenshot:
![image](https://github.com/user-attachments/assets/d409732b-080e-44c6-8abd-015a36d9ade6)

![image](https://github.com/user-attachments/assets/c8272b05-b958-4f7f-aa3f-884c7e06a78e)

I also made a separate entry for migrating from FlaskRESTPlus/RestX. I didn't create an open issue for this as the change is very simple.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
