### PR TITLE
fix broken migrations link

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ For some complete examples, see [/examples](https://github.com/apiflask/apiflask
 
 ## Relationship with Flask
 
-APIFlask is a thin wrapper on top of Flask. You only need to remember the following differences (see *[Migrating from Flask](https://apiflask.com/migrating)* for more details):
+APIFlask is a thin wrapper on top of Flask. You only need to remember the following differences (see *[Migrating from Flask](https://apiflask.com/migrations/flask/)* for more details):
 
 - When creating an application instance, use `APIFlask` instead of `Flask`.
 - When creating a blueprint instance, use `APIBlueprint` instead of `Blueprint`.


### PR DESCRIPTION
- Fixes the broken link to migrations on the README


Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [ ] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [ ] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [ ] Run `pytest` and `tox`, no tests failed.
