### PR TITLE
Fix OpenAPI spec for multiple content types (json_for_form)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,9 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: Linux, python: '3.12', os: ubuntu-latest, tox: py312}
-          - {name: Windows, python: '3.12', os: windows-latest, tox: py312}
-          - {name: Mac, python: '3.12', os: macos-latest, tox: py312}
+          - {name: '3.12 on Linux', python: '3.12', os: ubuntu-latest, tox: py312}
+          - {name: '3.12 on Windows', python: '3.12', os: windows-latest, tox: py312}
+          - {name: '3.12 on Mac', python: '3.12', os: macos-latest, tox: py312}
           - {name: '3.11', python: '3.11', os: ubuntu-latest, tox: py311}
           - {name: '3.10', python: '3.10', os: ubuntu-latest, tox: py310}
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 Released: -
 
+- Fix OpenAPI spec for multiple content types with `json_or_form` location ([issue #600][issue_600]).
+
+[issue_600]: https://github.com/apiflask/apiflask/issues/600
+
 
 ## Version 2.2.0
 

--- a/docs/request.md
+++ b/docs/request.md
@@ -46,6 +46,34 @@ def hello(headers_data, query_data, json_data):
 ```
 
 
+## Request body content types
+
+In the generated OpenAPI spec, the request body content type is set based on the input location you declared.
+
+- `json`: `application/json`
+- `form`: `application/x-www-form-urlencoded`
+- `files`: `multipart/form-data`
+- `form_and_files`: `multipart/form-data`
+- `json_or_form`: `application/json` and `application/x-www-form-urlencoded`. For this location, APIFlask will
+  try to parse the request body as JSON first, if it fails, it will try to parse it as form data. The OpenAPI spec
+  will show both content types, for example:
+
+    ```yaml
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              ...
+        application/x-www-form-urlencoded:
+          schema:
+            type: object
+            properties:
+              ...
+    ```
+
+
 ## Request body validating
 
 When you declared an input with `app.input` decorator, APIFlask (webargs) will get the data

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -1093,20 +1093,20 @@ class APIFlask(APIScaffold, Flask):
 
                 # requestBody
                 if view_func._spec.get('body'):
-                    content_type = view_func._spec.get('content_type', 'application/json')
-                    operation['requestBody'] = {
-                        'content': {
-                            content_type: {
-                                'schema': view_func._spec['body'],
-                            }
+                    content_types = view_func._spec.get('content_type')
+                    if not isinstance(content_types, list):
+                        content_types = [content_types]
+                    operation['requestBody'] = {'content': {}}
+                    for content_type in content_types:
+                        operation['requestBody']['content'][content_type] = {
+                            'schema': view_func._spec['body'],
                         }
-                    }
-                    if view_func._spec.get('body_example'):
-                        example = view_func._spec.get('body_example')
-                        operation['requestBody']['content'][content_type]['example'] = example
-                    if view_func._spec.get('body_examples'):
-                        examples = view_func._spec.get('body_examples')
-                        operation['requestBody']['content'][content_type]['examples'] = examples
+                        if view_func._spec.get('body_example'):
+                            example = view_func._spec.get('body_example')
+                            operation['requestBody']['content'][content_type]['example'] = example
+                        if view_func._spec.get('body_examples'):
+                            examples = view_func._spec.get('body_examples')
+                            operation['requestBody']['content'][content_type]['examples'] = examples
 
                 # security
                 if custom_security:  # custom security

--- a/src/apiflask/scaffold.py
+++ b/src/apiflask/scaffold.py
@@ -298,7 +298,13 @@ class APIScaffold:
                     'and "json_or_form").'
                 )
             if location == 'json':
-                _annotate(f, body=schema, body_example=example, body_examples=examples)
+                _annotate(
+                    f,
+                    body=schema,
+                    body_example=example,
+                    body_examples=examples,
+                    content_type='application/json',
+                )
             elif location == 'form':
                 _annotate(
                     f,
@@ -314,6 +320,14 @@ class APIScaffold:
                     body_example=example,
                     body_examples=examples,
                     content_type='multipart/form-data',
+                )
+            elif location == 'json_or_form':
+                _annotate(
+                    f,
+                    body=schema,
+                    body_example=example,
+                    body_examples=examples,
+                    content_type=['application/x-www-form-urlencoded', 'application/json'],
                 )
             else:
                 if not hasattr(f, '_spec') or f._spec.get('args') is None:
@@ -406,7 +420,7 @@ class APIScaffold:
                 See the [docs](https://apiflask.com/openapi/#response-links) for more details
                 about setting response links.
 
-            content_type: The content/media type of the response. It defautls to `application/json`.
+            content_type: The content/media type of the response. It defaults to `application/json`.
             headers: The schemas of the headers.
 
         *Version changed: 2.1.0*


### PR DESCRIPTION
The `json_or_form` location will generate the following spec:

```yaml
requestBody:
  content:
    application/json:
      schema:
        type: object
        properties:
          ...
    application/x-www-form-urlencoded:
      schema:
        type: object
        properties:
          ...
```

fixes #600

<!--
If needed, ensure each step in the checklist below is complete. If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [x] Run `pytest` and `tox`, no tests failed.
