### PR TITLE
Modify input validation skip to use webargs implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## Version 2.3.2
+
+Released: -
+
+- Fix input data loading implementation when input validation is skipped ([issue #629][issue_629]).
+
+[issue_629]: https://github.com/apiflask/apiflask/issues/629
+
+
 ## Version 2.3.1
 
 Released: 2024/12/7

--- a/src/apiflask/scaffold.py
+++ b/src/apiflask/scaffold.py
@@ -6,7 +6,7 @@ from functools import wraps
 
 from flask import current_app
 from flask import jsonify
-from flask import request
+from flask import request as flask_request
 from flask import Response
 from marshmallow import ValidationError as MarshmallowValidationError
 from webargs.flaskparser import FlaskParser as BaseFlaskParser
@@ -55,9 +55,14 @@ class FlaskParser(BaseFlaskParser):
             error_headers,
         )
 
+    def load_location_data(self, schema: Schema, location: str) -> t.Any:
+        """
+        Expose the internal `_load_location_data` method to support loading data without validation
+        """
+        return self._load_location_data(schema=schema, req=flask_request, location=location)
+
 
 parser: FlaskParser = FlaskParser()
-use_args: t.Callable = parser.use_args
 
 
 def _get_files_and_form(request, schema):
@@ -99,46 +104,6 @@ def _generate_schema_from_mapping(schema: DictSchemaType, schema_name: str | Non
     if schema_name is None:
         schema_name = 'GeneratedSchema'
     return Schema.from_dict(schema, name=schema_name)()  # type: ignore
-
-
-def _load_raw_data(location: str = 'json') -> dict[t.Any, t.Any]:
-    """
-    Load raw data from the specified location in the request.
-
-    Arguments:
-        location (str): Specifies the source of the data to load, which can be one of the following:
-            - `json`: Load data from the request's JSON body.
-            - `form`: Load data from the request's form.
-            - `files` or `form_and_files`: Load data from both the request's form and files.
-            - `json_or_form`: Preferably load data from the request's JSON body or request's form.
-            - `query`: Load data from the request's query parameters.
-            - `path`: Load data from the request's view arguments.
-
-            `headers` and `cookies` are not supported by this function.
-
-    Returns:
-        dict: A dictionary containing the data loaded from the specified location.
-
-    Raises:
-        ValueError: If the provided location argument is not one of the expected values.
-    """
-    if location == 'json':
-        if request.is_json:
-            return request.get_json() or {}
-        return {}
-    if location == 'form':
-        return request.form.to_dict()
-    if location in ['files', 'form_and_files']:
-        return {**request.files.to_dict(), **request.form.to_dict()}
-    if location == 'json_or_form':
-        if request.is_json:
-            return request.get_json() or {}
-        return request.form.to_dict()
-    if location in ['query', 'querystring']:
-        return request.args.to_dict()
-    if location == 'path':
-        return request.view_args or {}
-    raise ValueError(f'Invalid location argument: {location}')
 
 
 class APIScaffold:
@@ -385,19 +350,19 @@ class APIScaffold:
                 # TODO: Support set example for request parameters
                 f._spec['args'].append((schema, location))
 
+            arg_name_val = arg_name or f'{location}_data'
+
             if not validation:
 
                 @wraps(f)
                 def wrapper(*args: t.Any, **kwargs: t.Any):
-                    raw_data = _load_raw_data(location)
-                    kwargs[f'{location}_data'] = raw_data
+                    location_data = parser.load_location_data(schema=schema, location=location)
+                    kwargs[arg_name_val] = location_data
                     return f(*args, **kwargs)
 
                 return wrapper
 
-            return use_args(
-                schema, location=location, arg_name=arg_name or f'{location}_data', **kwargs
-            )(f)
+            return parser.use_args(schema, location=location, arg_name=arg_name_val, **kwargs)(f)
 
         return decorator
 


### PR DESCRIPTION
Modified the `@input` data loading logic for the `validation=False` case by replacing the hand-rolled data loading implementation with an implementation from elements within the `webargs` library. Also fixed an undocumented issue where the `arg_name` parameter was not properly handled when input validation is skipped.

Fixes #629.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
