### PR TITLE
Modify response headers to be compliant with OAS 3.0.0+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## Version 2.3.2
+
+Released: -
+
+- Fix response headers to be compliant with the OpenAPI specification for versions 3.0.0+ ([issue #631][issue_631]).
+
+[issue_631]: https://github.com/apiflask/apiflask/issues/631
+
+
 ## Version 2.3.1
 
 Released: 2024/12/7
@@ -79,7 +88,7 @@ Released: 2023/12/16
 - Allow adding multiple media types for a response ([issue #494][issue_494]).
 - Support adding headers to the response schema ([issue #507][issue_507]).
 - Add support for adding decorators to the OpenAPI spec and documentation UI endpoints ([issue #483][issue_483]).
-- Fix the base repsonse schema inconsistency issue.
+- Fix the base response schema inconsistency issue.
 
 [issue_494]: https://github.com/apiflask/apiflask/issues/494
 [issue_507]: https://github.com/apiflask/apiflask/issues/507

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -1253,12 +1253,14 @@ class APIFlask(APIScaffold, Flask):
         if links is not None:
             operation['responses'][status_code]['links'] = links
         if headers_schema is not None:
-            headers = self._ma_plugin.converter.schema2parameters(  # type: ignore
+            header_params = self._ma_plugin.converter.schema2parameters(  # type: ignore
                 headers_schema, location='headers'
             )
-            operation['responses'][status_code]['headers'] = {
-                header['name']: header for header in headers
-            }
+            headers = {header['name']: header for header in header_params}
+            for header in headers.values():
+                header.pop('in', None)
+                header.pop('name', None)
+            operation['responses'][status_code]['headers'] = headers
 
     def _add_response_with_schema(
         self,


### PR DESCRIPTION
Modified the response headers generation to omit the `in` and `name` fields from being included in the generated specification, per OAS 3.0.0+.

Fixes #631.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
