### PR TITLE
fix(BryantHe): Convert the relative redirect path of OAuth2 to an absolute redirect URL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## Version 2.3.3
+
+Released: TODO
+
+- Convert the relative redirect path of OAuth2 to an absolute redirect URL. ([issue #602][issue_602]).
+
+[issue_602]: https://github.com/apiflask/apiflask/issues/602
+
+
 ## Version 2.3.2
 
 Released: 2024/12/15

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -509,6 +509,10 @@ class APIFlask(APIScaffold, Flask):
         The name of the blueprint is "openapi". This blueprint will hold the view
         functions for spec file and API docs.
 
+        *Version changed: 2.3.2*
+
+        - Convert the relative redirect path of OAuth2 to an absolute redirect URL.
+
         *Version changed: 2.1.0*
 
         - Inject the OpenAPI endpoints decorators.
@@ -553,7 +557,10 @@ class APIFlask(APIScaffold, Flask):
                     ui_templates[self.docs_ui],
                     title=self.title,
                     version=self.version,
-                    oauth2_redirect_path=self.docs_oauth2_redirect_path,
+                    oauth2_redirect_path=request.url_root.rstrip('/')
+                    + self.docs_oauth2_redirect_path
+                    if self.docs_oauth2_redirect_path
+                    else None,
                 )
 
             if self.docs_ui == 'swagger-ui':

--- a/tests/test_openapi_blueprint.py
+++ b/tests/test_openapi_blueprint.py
@@ -59,7 +59,7 @@ def test_docs_oauth2_redirect_path(client):
     assert b'<title>Swagger UI: OAuth2 Redirect</title>' in rv.data
     rv = client.get('/docs')
     assert rv.status_code == 200
-    assert b'oauth2RedirectUrl: "/docs/oauth2-redirect"' in rv.data
+    assert b'oauth2RedirectUrl: "http://localhost/docs/oauth2-redirect"' in rv.data
 
     app = APIFlask(__name__, docs_oauth2_redirect_path='/docs/oauth2/redirect')
     rv = app.test_client().get('/docs/oauth2/redirect')
@@ -67,7 +67,7 @@ def test_docs_oauth2_redirect_path(client):
     assert b'<title>Swagger UI: OAuth2 Redirect</title>' in rv.data
     rv = app.test_client().get('/docs')
     assert rv.status_code == 200
-    assert b'oauth2RedirectUrl: "/docs/oauth2/redirect"' in rv.data
+    assert b'oauth2RedirectUrl: "http://localhost/docs/oauth2/redirect"' in rv.data
 
     app = APIFlask(__name__, docs_oauth2_redirect_path=None)
     assert app.docs_oauth2_redirect_path is None


### PR DESCRIPTION
Convert the relative redirect path of OAuth2 to an absolute redirect URL.

Fixes #602.

Checklist:

* [x]  Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
* [x]  Add or update relevant docs, in the `docs` folder and in code docstring.
* [x]  Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
* [x]  Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
* [x]  Run `pytest` and `tox`, no tests failed.
