### PR TITLE
Change default OpenAPI server URL to /

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,10 @@
 Released: -
 
 - Add 'docs_oauth2_redirect_path_external' parameter to support absolute redirect url ([issue #602][issue_602]).
+- Change default OpenAPI server URL to `/` ([issue #638][issue_638]).
 
 [issue_602]: https://github.com/apiflask/apiflask/issues/602
+[issue_638]: https://github.com/apiflask/apiflask/issues/638
 
 
 ## Version 2.3.2

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -11,11 +11,9 @@ from apispec import BasePlugin
 from apispec.ext.marshmallow import MarshmallowPlugin
 from flask import Blueprint
 from flask import Flask
-from flask import has_request_context
 from flask import json
 from flask import jsonify
 from flask import render_template_string
-from flask import request
 from flask import url_for
 from flask.config import ConfigAttribute
 from flask.wrappers import Response
@@ -817,8 +815,8 @@ class APIFlask(APIScaffold, Flask):
         if self.servers:
             kwargs['servers'] = self.servers
         else:
-            if self.config['AUTO_SERVERS'] and has_request_context():
-                kwargs['servers'] = [{'url': request.url_root}]
+            if self.config['AUTO_SERVERS']:
+                kwargs['servers'] = [{'url': '/'}]
         if self.external_docs:
             kwargs['externalDocs'] = self.external_docs
 

--- a/tests/test_openapi_basic.py
+++ b/tests/test_openapi_basic.py
@@ -2,7 +2,6 @@ import json
 
 import openapi_spec_validator as osv
 import pytest
-from flask import request
 
 from .schemas import Bar
 from .schemas import Baz
@@ -188,7 +187,7 @@ def test_default_servers(app):
     with app.test_request_context():
         assert rv.json['servers'] == [
             {
-                'url': f'{request.url_root}',
+                'url': '/',
             },
         ]
 
@@ -196,7 +195,11 @@ def test_default_servers(app):
 def test_default_servers_without_req_context(cli_runner):
     result = cli_runner.invoke(spec_command)
     assert 'openapi' in result.output
-    assert 'servers' not in json.loads(result.output)
+    assert json.loads(result.output)['servers'] == [
+        {
+            'url': '/',
+        },
+    ]
 
 
 def test_auto_200_response(app, client):


### PR DESCRIPTION
Change default OpenAPI server URL to `/`.


fixes #638 


Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
