### PR TITLE
Fix app.route example in usage documentation page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 Released: -
 
 - Add 'docs_oauth2_redirect_path_external' parameter to support absolute redirect url ([issue #602][issue_602]).
+- Replace `app.post` by `app.route` in usage documentation page
 
 [issue_602]: https://github.com/apiflask/apiflask/issues/602
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -324,7 +324,7 @@ Read the *[API Documentations](/api-docs)* chapter for the advanced topics on AP
 To create a view function, instead of using `app.route` and set the `methods`:
 
 ```python
-@app.post('/pets', methods=['POST'])
+@app.route('/pets', methods=['POST'])
 def create_pet():
     return {'message': 'created'}, 201
 ```


### PR DESCRIPTION
The documentation mentions `@app.route` but the example mistakenly uses `@app.post`.

