### PR TITLE
Replace UNPKG w/ jsDelivr

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,10 @@
 Released: -
 
 - Add 'docs_oauth2_redirect_path_external' parameter to support absolute redirect url ([issue #602][issue_602]).
+- Update the redoc's default settings to use jsDelivr by default instead ([pr #650](pr_650)).
 
 [issue_602]: https://github.com/apiflask/apiflask/issues/602
+[pr_650]: https://github.com/apiflask/apiflask/pull/650
 
 
 ## Version 2.3.2

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1158,7 +1158,7 @@ app.config['SWAGGER_UI_OAUTH_CONFIG'] = {
 The absolute or relative URL of the Elements CSS file.
 
 - Type: `str`
-- Default value: `'https://unpkg.com/@stoplight/elements/styles.min.css'`
+- Default value: `'https://cdn.jsdelivr.net/npm/@stoplight/elements/styles.min.css'`
 - Examples:
 
 ```python
@@ -1171,7 +1171,7 @@ app.config['ELEMENTS_CSS'] = 'https://cdn.jsdelivr.net/npm/@stoplight/elements-d
 The absolute or relative URL of the Elements JavaScript file.
 
 - Type: `str`
-- Default value: `'https://unpkg.com/@stoplight/elements/web-components.min.js'`
+- Default value: `'https://cdn.jsdelivr.net/npm/@stoplight/elements/web-components.min.js'`
 - Examples:
 
 ```python
@@ -1221,7 +1221,7 @@ app.config['ELEMENTS_CONFIG'] = {
 The absolute or relative URL of the RapiDoc JavaScript file.
 
 - Type: `str`
-- Default value: `'https://unpkg.com/rapidoc/dist/rapidoc-min.js'`
+- Default value: `'https://cdn.jsdelivr.net/npm/rapidoc/dist/rapidoc-min.js'`
 - Examples:
 
 ```python
@@ -1271,7 +1271,7 @@ app.config['RAPIDOC_CONFIG'] = {
 The absolute or relative URL of the RapiPDF JavaScript file.
 
 - Type: `str`
-- Default value: `'https://unpkg.com/rapipdf/dist/rapipdf-min.js'`
+- Default value: `'https://cdn.jsdelivr.net/npm/rapipdf/dist/rapipdf-min.js'`
 - Examples:
 
 ```python

--- a/examples/openapi/static_docs/index.html
+++ b/examples/openapi/static_docs/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <title>APIFlask 0.1.0 - Swagger UI</title>
-  <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css">
+  <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css">
   <link rel="icon" type="image/png"
     href="https://apiflask.com/_assets/favicon.png">
   <style>
@@ -30,8 +30,8 @@
 <body>
   <div id="swagger-ui"></div>
 
-  <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
-  <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-standalone-preset.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-standalone-preset.js"></script>
   <script>
     // we can get several config items of Function type
     // referring to https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/

--- a/src/apiflask/settings.py
+++ b/src/apiflask/settings.py
@@ -57,22 +57,22 @@ REDOC_USE_GOOGLE_FONT: bool = True
 REDOC_STANDALONE_JS: str = 'https://cdn.redoc.ly/redoc/latest/bundles/\
 redoc.standalone.js'  # TODO: rename to REDOC_JS
 REDOC_CONFIG: dict | None = None
-SWAGGER_UI_CSS: str = 'https://unpkg.com/swagger-ui-dist/swagger-ui.css'
-SWAGGER_UI_BUNDLE_JS: str = 'https://unpkg.com/swagger-ui-dist/\
+SWAGGER_UI_CSS: str = 'https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css'
+SWAGGER_UI_BUNDLE_JS: str = 'https://cdn.jsdelivr.net/npm/swagger-ui-dist/\
 swagger-ui-bundle.js'  # TODO: rename to SWAGGER_UI_JS
-SWAGGER_UI_STANDALONE_PRESET_JS: str = 'https://unpkg.com/swagger-ui-dist/\
+SWAGGER_UI_STANDALONE_PRESET_JS: str = 'https://cdn.jsdelivr.net/npm/swagger-ui-dist/\
 swagger-ui-standalone-preset.js'  # TODO: rename to SWAGGER_UI_STANDALONE_JS
 SWAGGER_UI_LAYOUT: str = 'BaseLayout'
 SWAGGER_UI_CONFIG: dict | None = None
 SWAGGER_UI_OAUTH_CONFIG: dict | None = None
-ELEMENTS_JS: str = 'https://unpkg.com/@stoplight/elements/web-components.min.js'
-ELEMENTS_CSS: str = 'https://unpkg.com/@stoplight/elements/styles.min.css'
+ELEMENTS_JS: str = 'https://cdn.jsdelivr.net/npm/@stoplight/elements/web-components.min.js'
+ELEMENTS_CSS: str = 'https://cdn.jsdelivr.net/npm/@stoplight/elements/styles.min.css'
 ELEMENTS_LAYOUT: str = 'sidebar'
 ELEMENTS_CONFIG: dict | None = None
-RAPIDOC_JS: str = 'https://unpkg.com/rapidoc/dist/rapidoc-min.js'
+RAPIDOC_JS: str = 'https://cdn.jsdelivr.net/npm/rapidoc/dist/rapidoc-min.js'
 RAPIDOC_THEME: str = 'light'
 RAPIDOC_CONFIG: dict | None = None
-RAPIPDF_JS: str = 'https://unpkg.com/rapipdf/dist/rapipdf-min.js'
+RAPIPDF_JS: str = 'https://cdn.jsdelivr.net/npm/rapipdf/dist/rapipdf-min.js'
 RAPIPDF_CONFIG: dict | None = None
 
 # Version changed: 1.2.0


### PR DESCRIPTION
UNPKG has not been actively maintained and ~~has been down since `Mar 15, 2025`~~ was down from Mar 15, 2025, 2:00 AM and down for 18 hours (https://github.com/unpkg/unpkg/issues/412). Migrating to jsDelivr means a more stable and reliant service.

The PR replaces UNPKG in the redoc default settings w/ jsDelivr. The docs has also been updated correspondingly.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [ ] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [ ] Run `pytest` and `tox`, no tests failed.
