### PR TITLE
Fix `apispec` version conflict

### DIFF
--- a/tests/test_decorator_doc.py
+++ b/tests/test_decorator_doc.py
@@ -1,9 +1,15 @@
+from importlib import metadata
+
 import openapi_spec_validator as osv
 import pytest
 from flask.views import MethodView
+from packaging.version import Version
 
 from .schemas import CustomHTTPError
 from .schemas import Foo
+
+
+apispec_version = Version(metadata.version('apispec'))
 
 
 def test_doc_summary_and_description(app, client):
@@ -260,9 +266,8 @@ def test_doc_responses_custom_spec(app, client):
     assert rv.json['paths']['/bar']['get']['responses']['400']['content']['application/json'][
         'schema'
     ] == {'$ref': '#/components/schemas/CustomHTTPError'}
-    import sys
 
-    if sys.version_info >= (3, 9):
+    if apispec_version >= Version('6.8.3'):
         assert rv.json['components']['schemas']['CustomHTTPError'] == {
             'type': 'object',
             'properties': {

--- a/tests/test_decorator_input.py
+++ b/tests/test_decorator_input.py
@@ -1,8 +1,10 @@
 import io
+from importlib import metadata
 
 import openapi_spec_validator as osv
 import pytest
 from flask.views import MethodView
+from packaging.version import Version
 from werkzeug.datastructures import FileStorage
 
 from .schemas import Bar
@@ -15,6 +17,9 @@ from apiflask import Schema
 from apiflask.fields import String
 from apiflask.validators import Length
 from apiflask.validators import OneOf
+
+
+apispec_version = Version(metadata.version('apispec'))
 
 
 def test_input(app, client):
@@ -349,9 +354,8 @@ def test_input_with_dict_schema(app, client):
         ]
         == '#/components/schemas/MyName'
     )
-    import sys
 
-    if sys.version_info >= (3, 9):
+    if apispec_version >= Version('6.8.3'):
         assert rv.json['components']['schemas']['MyName'] == {
             'properties': {'name': {'type': 'string'}},
             'required': ['name'],

--- a/tests/test_decorator_output.py
+++ b/tests/test_decorator_output.py
@@ -1,14 +1,19 @@
 from dataclasses import dataclass
+from importlib import metadata
 
 import openapi_spec_validator as osv
 from flask import make_response
 from flask.views import MethodView
+from packaging.version import Version
 
 from .schemas import Foo
 from .schemas import Query
 from apiflask import Schema
 from apiflask.fields import Field
 from apiflask.fields import String
+
+
+apispec_version = Version(metadata.version('apispec'))
 
 
 def test_output(app, client):
@@ -159,9 +164,8 @@ def test_output_with_dict_schema(app, client):
         ]['$ref']
         == '#/components/schemas/MyName'
     )
-    import sys
 
-    if sys.version_info >= (3, 9):
+    if apispec_version >= Version('6.8.3'):
         assert rv.json['components']['schemas']['MyName'] == {
             'properties': {'name': {'type': 'string'}},
             'type': 'object',


### PR DESCRIPTION
Fix `apispec` [version conflict](https://apispec.readthedocs.io/en/latest/changelog.html) for tests.

<img width="1380" height="832" alt="image" src="https://github.com/user-attachments/assets/295e490e-f89c-46a8-908b-2c24424366bf" />

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the `docs` folder and in code docstring.
- [ ] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [ ] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
