### PR TITLE
Update the default schema name resolver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,8 @@ Released: -
 - Add support for Pydantic models as data schemas ([issue #519][issue_519]).
 - Fix subclassed MethodView resources cannot be added as URL rules ([issue #618][issue_618]).
 - Add support for API key auth with `APIKeyHeaderAuth`, `APIKeyCookieAuth`, and `APIKeyQueryAuth`. Add support for runtime selection of authentication methods with `MultiAuth`. Deprecate the API key auth with HTTPTokenAuth ([issue #604][issue_604]).
-- Removed implicit security scheme naming rules ([pr #665](pr_665)).
+- Remove implicit security scheme naming rules ([pr #665](pr_665)).
+- Remove implicit schema naming change (i.e. 'Schema' suffix stripping).
 
 [issue_519]: https://github.com/apiflask/apiflask/issues/519
 [pr_690]: https://github.com/apiflask/apiflask/pull/690

--- a/docs/schema/marshmallow.md
+++ b/docs/schema/marshmallow.md
@@ -209,8 +209,6 @@ the default schema name resolver used in APIFlask:
 ```python
 def schema_name_resolver(schema):
     name = schema.__class__.__name__  # get schema class name
-    if name.endswith('Schema'):  # remove the "Schema" suffix
-        name = name[:-6] or name
     if schema.partial:  # add a "Update" suffix for partial schema
         name += 'Update'
     return name
@@ -225,7 +223,7 @@ from apiflask import APIFlask
 
 def my_schema_name_resolver(schema):
     name = schema.__class__.__name__
-    if name.endswith('Schema'):
+    if name.endswith('Schema'):  # remove the "Schema" suffix
         name = name[:-6] or name
     if schema.partial:
         name += 'Partial'

--- a/src/apiflask/schema_adapters/marshmallow.py
+++ b/src/apiflask/schema_adapters/marshmallow.py
@@ -157,16 +157,18 @@ class MarshmallowAdapter(SchemaAdapter):
         return result
 
     def get_schema_name(self) -> str:
-        """Get schema name for OpenAPI documentation."""
+        """Get schema name for OpenAPI documentation.
+
+        *Version changed: 3.0.0*
+
+        - Remove "Schema" suffix stripping from schema names.
+
+        """
         schema = self.schema
         if isinstance(schema, type):  # pragma: no cover
             schema = schema()  # type: ignore
 
         name: str = schema.__class__.__name__
-
-        if name.endswith('Schema'):
-            # TODO: consider keeping the original name
-            name = name[:-6] or name
         if hasattr(schema, 'partial') and schema.partial:
             name += 'Update'
         return name

--- a/tests/test_decorator_input.py
+++ b/tests/test_decorator_input.py
@@ -367,13 +367,13 @@ def test_input_with_dict_schema(app, client):
         rv.json['paths']['/baz']['post']['requestBody']['content']['application/json']['schema'][
             '$ref'
         ]
-        == '#/components/schemas/Generated'
+        == '#/components/schemas/GeneratedSchema'
     )
     assert (
         rv.json['paths']['/spam']['post']['requestBody']['content']['application/json']['schema'][
             '$ref'
         ]
-        == '#/components/schemas/Generated1'
+        == '#/components/schemas/GeneratedSchema1'
     )
 
 

--- a/tests/test_decorator_output.py
+++ b/tests/test_decorator_output.py
@@ -182,13 +182,13 @@ def test_output_with_dict_schema(app, client):
         rv.json['paths']['/baz']['get']['responses']['200']['content']['application/json'][
             'schema'
         ]['$ref']
-        == '#/components/schemas/Generated'
+        == '#/components/schemas/GeneratedSchema'
     )
     assert (
         rv.json['paths']['/spam']['get']['responses']['200']['content']['application/json'][
             'schema'
         ]['$ref']
-        == '#/components/schemas/Generated1'
+        == '#/components/schemas/GeneratedSchema1'
     )
 
 

--- a/tests/test_decoupling_integration.py
+++ b/tests/test_decoupling_integration.py
@@ -156,8 +156,8 @@ def test_body_schema_registration_generated_schemas(app, client):
     generated_schemas = [name for name in schemas if name.startswith('Generated')]
 
     assert len(generated_schemas) == 2
-    assert 'Generated' in generated_schemas
-    assert 'Generated1' in generated_schemas
+    assert 'GeneratedSchema' in generated_schemas
+    assert 'GeneratedSchema1' in generated_schemas
 
 
 def test_parameters_use_openapi_helper(app, client):
@@ -356,7 +356,7 @@ def test_unique_schema_names_for_different_schemas(app, client):
     osv.validate(rv.json)
 
     # Same schema class should be registered once and reused
-    assert 'Item' in rv.json['components']['schemas']
+    assert 'ItemSchema' in rv.json['components']['schemas']
 
     post1_schema = rv.json['paths']['/items1']['post']['requestBody']['content'][
         'application/json'

--- a/tests/test_openapi_adapters.py
+++ b/tests/test_openapi_adapters.py
@@ -171,16 +171,6 @@ class TestOpenAPIHelper:
             params = helper.schema_to_parameters(schema, location=input_loc)
             assert all(p['in'] == expected_loc for p in params)
 
-    def test_get_schema_name_marshmallow(self):
-        """Test get_schema_name with marshmallow schema."""
-        helper = OpenAPIHelper()
-        schema = SimpleSchema()
-
-        name = helper.get_schema_name(schema)
-
-        # Schema name should strip 'Schema' suffix
-        assert name == 'Simple'
-
     def test_get_schema_name_dict(self):
         """Test get_schema_name with dict schema."""
         helper = OpenAPIHelper()
@@ -189,7 +179,7 @@ class TestOpenAPIHelper:
         name = helper.get_schema_name(schema)
 
         # Dict schemas get 'Generated' prefix
-        assert name == 'Generated'
+        assert name == 'GeneratedSchema'
 
     def test_schema_to_spec_unknown_type(self):
         """Test schema_to_spec with unknown schema type."""

--- a/tests/test_schema_adapters.py
+++ b/tests/test_schema_adapters.py
@@ -113,15 +113,6 @@ class TestMarshmallowAdapter:
 
         assert isinstance(adapter.schema, EmptySchema)
 
-    def test_get_schema_name_regular(self):
-        """Test get_schema_name with regular schema."""
-        adapter = MarshmallowAdapter(PetSchema())
-
-        name = adapter.get_schema_name()
-
-        # Should strip 'Schema' suffix
-        assert name == 'Pet'
-
     def test_get_schema_name_partial(self):
         """Test get_schema_name with partial schema."""
         schema = PetSchema(partial=True)
@@ -130,18 +121,7 @@ class TestMarshmallowAdapter:
         name = adapter.get_schema_name()
 
         # Partial schemas should append 'Update'
-        assert name == 'PetUpdate'
-
-    def test_get_schema_name_no_suffix(self):
-        """Test get_schema_name when name doesn't end with Schema."""
-
-        class Pet(Schema):
-            name = fields.String()
-
-        adapter = MarshmallowAdapter(Pet())
-        name = adapter.get_schema_name()
-
-        assert name == 'Pet'
+        assert name == 'PetSchemaUpdate'
 
     # Note: get_openapi_schema is tested via openapi_helper in integration tests
     # Direct adapter usage is internal and may vary


### PR DESCRIPTION
Stop stripping the `Schema` suffix for marshmallow schema.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
