### PR TITLE
Deprecate EmptySchema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,13 +9,17 @@ Released: -
 - Fix subclassed MethodView resources cannot be added as URL rules ([issue #618][issue_618]).
 - Add support for API key auth with `APIKeyHeaderAuth`, `APIKeyCookieAuth`, and `APIKeyQueryAuth`. Add support for runtime selection of authentication methods with `MultiAuth`. Deprecate the API key auth with HTTPTokenAuth ([issue #604][issue_604]).
 - Remove implicit security scheme naming rules ([pr #665](pr_665)).
-- Remove implicit schema naming change (i.e. 'Schema' suffix stripping).
+- Remove implicit schema naming change (i.e. 'Schema' suffix stripping) ([pr #693](pr_693)).
+- Deprecate the `EmptySchema` class. Use empty dict `{}` instead ([pr #694][pr_694]).
+- Remove the deprecated `__version__` attribute. Use feature detection or `importlib.metadata.version("apiflask")` instead.
 
 [issue_519]: https://github.com/apiflask/apiflask/issues/519
 [pr_690]: https://github.com/apiflask/apiflask/pull/690
 [issue_618]: https://github.com/apiflask/apiflask/issues/618
 [issue_604]: https://github.com/apiflask/apiflask/issues/604
 [pr_655]: https://github.com/apiflask/apiflask/pull/655
+[pr_693]: https://github.com/apiflask/apiflask/pull/693
+[pr_694]: https://github.com/apiflask/apiflask/pull/694
 
 
 ## Version 2.4.0

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -787,7 +787,7 @@ def get_foo():
 
     This feature was added in the [version 2.0.0](/changelog/#version-0200).
 
-When you create an endpoint to return a file, the `FileSchema` should be used:
+When you create an endpoint to return a file, the `FileSchema` should be used (only marshmallow is supported for now):
 
 ```python
 from apiflask.schemas import FileSchema
@@ -800,16 +800,7 @@ def get_image(filename):
 ```
 
 Acoording the OpenAPI spec, the schema may be omit if the file format is binary, so you
-can also use `EmptySchema`:
-
-```python
-from apiflask.schemas import EmptySchema
-
-@app.get('/images/<filename>')
-@app.output(EmptySchema, content_type='image/png')
-```
-
-Or:
+can also use an empty dict `{}` as the schema:
 
 ```python
 @app.get('/images/<filename>')

--- a/docs/response.md
+++ b/docs/response.md
@@ -20,7 +20,7 @@ Basic concepts on response formatting:
 
 ## Pagination support
 
-APIFlask provides two utilies for pagination:
+For marshmallow, APIFlask provides two utilies for pagination:
 
 - [apiflask.PaginationSchema](/api/schemas/#apiflask.schemas.PaginationSchema)
 - [apiflask.pagination_builder](/api/helpers/#apiflask.helpers.pagination_builder)

--- a/src/apiflask/__init__.py
+++ b/src/apiflask/__init__.py
@@ -1,5 +1,3 @@
-import typing as t
-
 from . import fields as fields
 from . import validators as validators
 from .app import APIFlask as APIFlask
@@ -18,20 +16,3 @@ from .security import APIKeyQueryAuth as APIKeyQueryAuth
 from .security import HTTPBasicAuth as HTTPBasicAuth
 from .security import HTTPTokenAuth as HTTPTokenAuth
 from .security import MultiAuth as MultiAuth
-
-
-def __getattr__(name: str) -> t.Any:  # pragma: no cover
-    if name == '__version__':
-        import importlib.metadata
-        import warnings
-
-        warnings.warn(
-            "The '__version__' attribute is deprecated and will be removed in"
-            ' APIFlask 3.0.0. Use feature detection or'
-            ' \'importlib.metadata.version("apiflask")\' instead.',
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return importlib.metadata.version('apiflask')
-
-    raise AttributeError(name)

--- a/src/apiflask/schemas.py
+++ b/src/apiflask/schemas.py
@@ -51,27 +51,9 @@ class Schema(BaseSchema):
 class EmptySchema(Schema):
     """An empty schema used to generate empty response/schema.
 
-    For 204 response, you can use this schema to
-    generate an empty response body. For 200 response, you can use this schema
-    to generate an empty response body schema.
+    *Version changed: 3.0.0*
 
-    Example:
-
-    ```python
-    @app.delete('/foo')
-    @app.output(EmptySchema, status_code=204)
-    def delete_foo():
-        return ''
-    ```
-
-    It equals to use `{}`:
-
-    ```python
-    @app.delete('/foo')
-    @app.output({}, status_code=204)
-    def delete_foo():
-        return ''
-    ```
+    - Removed from docs and should only be used internally. Use `{}` instead.
     """
 
     pass


### PR DESCRIPTION
Use `{}` instead.

Checklist:

- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
