### PR TITLE
Add a cookies tip

### DIFF
--- a/docs/request.md
+++ b/docs/request.md
@@ -29,7 +29,7 @@ The following location are supported:
 
 !!! tip
 
-    Cookie parameters don't work well with OpenAPI, please read [this issue](https://github.com/apiflask/apiflask/issues/705) for more details.
+    Cookie parameters don't work well with OpenAPI, see this [issue](https://github.com/apiflask/apiflask/issues/705) for more details.
 
 You can declare multiple input data with multiple `app.input` decorators. However,
 you can only declare one body location for your view function, one of:


### PR DESCRIPTION
Add a tip for cookies parameters with OpenAPI, see #705 for more details.