### PR TITLE
Release 3.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Version: 3.1.0
 
-Released: -
+Released: 2026/3/21
 
 - Add FileModel for Pydantic ([issue #701][issue_701]).
 - Support pagination with Pydantic ([issue #702][issue_702]).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "A lightweight web API framework based on Flask."
 readme = "README.md"
 license = { text = "MIT" }
 authors = [{ name = "Grey Li", email = "withlihui@gmail.com" }]
-version = "3.0.2"
+version = "3.1.0"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",


### PR DESCRIPTION
- Add FileModel for Pydantic issue #701.
- Support pagination with Pydantic issue #702.
- Fix `@app.output(Schema(many=True))` is not `array` type in OpenAPI doc issue #721.
- Fix type checking for view function return types issue #734.