### PR TITLE
docs(request.md): document headers location field name mapping

### DIFF
--- a/docs/request.md
+++ b/docs/request.md
@@ -60,9 +60,11 @@ which schema library you're using.
 #### With marshmallow
 
 The marshmallow adapter delegates header parsing to
-[webargs](https://github.com/marshmallow-code/webargs), which looks up each
-header by the schema field name as-is. To match a header that contains
-dashes or uppercase letters, declare the field with `data_key` set to the
+[webargs](https://github.com/marshmallow-code/webargs). HTTP header names are
+matched case-insensitively, so uppercase letters do not by themselves require
+special handling. However, if the actual header name differs from the schema
+field name—especially when it contains characters that are not valid in Python
+identifiers, such as dashes—declare the field with `data_key` set to the
 actual HTTP header name:
 
 ```python

--- a/docs/request.md
+++ b/docs/request.md
@@ -49,6 +49,74 @@ def hello(headers_data, query_data, json_data):
     pass
 ```
 
+### Request location with headers
+
+HTTP header names are case-insensitive and conventionally contain dashes
+(for example, `X-Token` or `Content-Type`). Python identifiers, however,
+cannot contain dashes, so APIFlask needs a way to bridge HTTP header names
+and the field names you declare on your schema. The exact rule depends on
+which schema library you're using.
+
+#### With marshmallow
+
+The marshmallow adapter delegates header parsing to
+[webargs](https://github.com/marshmallow-code/webargs), which looks up each
+header by the schema field name as-is. To match a header that contains
+dashes or uppercase letters, declare the field with `data_key` set to the
+actual HTTP header name:
+
+```python
+from apiflask import APIFlask, Schema
+from apiflask.fields import String
+
+app = APIFlask(__name__)
+
+
+class HeaderIn(Schema):
+    x_token = String(required=True, data_key='X-Token')
+
+
+@app.get('/')
+@app.input(HeaderIn, location='headers')
+def hello(headers_data):
+    return {'token': headers_data['x_token']}
+```
+
+Headers whose name is already a valid Python identifier (for example,
+`authorization`) can be matched directly without `data_key`.
+
+#### With Pydantic
+
+The Pydantic adapter normalizes every incoming header name before
+validation by lowercasing it and replacing dashes with underscores. So
+`X-Token` becomes `x_token`, `X-API-Version` becomes `x_api_version`, and
+`Content-Type` becomes `content_type`. As a result, you simply declare
+snake_case fields on your model — no `data_key` or alias is needed:
+
+```python
+from apiflask import APIFlask
+from pydantic import BaseModel
+
+app = APIFlask(__name__)
+
+
+class HeaderIn(BaseModel):
+    x_token: str
+
+
+@app.get('/')
+@app.input(HeaderIn, location='headers')
+def hello(headers_data: HeaderIn):
+    return {'token': headers_data.x_token}
+```
+
+!!! warning
+
+    The two adapters are not symmetric here: marshmallow requires an
+    explicit `data_key` for any hyphenated header, while Pydantic
+    normalizes header names automatically. When porting a schema between
+    the two, remember to add or remove `data_key` accordingly.
+
 
 ## Request body content types
 


### PR DESCRIPTION
Explain how marshmallow (via data_key) and Pydantic (auto lower/dash-to- underscore normalization) map HTTP header names to schema fields, and note the asymmetry between the two adapters.

<!--
For features and bug fixes, before opening a PR, please open an issue describing
the bug or feature the PR will address. You can skip this step if it's a typo fix.

Replace this comment with a description of the change. Describe how it
addresses the linked issue.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->


<!--
If needed, ensure each step in the checklist below is complete. If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [ ] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [ ] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
