### PR TITLE
feat(exceptions): add __str__ method to HTTPError

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 Released: -
 
 - Support flask-httpauth 4.8.1+ ([issue #743][issue_743]).
+- Add `__str__` method to `HTTPError` to return a human-readable string representation ([issue #748][issue_748]).
+
+[issue_748]: https://github.com/apiflask/apiflask/issues/748
 
 [issue_743]: https://github.com/apiflask/apiflask/issues/743
 

--- a/src/apiflask/exceptions.py
+++ b/src/apiflask/exceptions.py
@@ -91,6 +91,20 @@ class HTTPError(Exception):
             # make sure the error message is not empty
             self.message: str = get_reason_phrase(self.status_code, 'Unknown error')
 
+    def __str__(self) -> str:
+        return f'<status_code={self.status_code}, message={self.message}>'
+
+    def __repr__(self) -> str:
+        return (
+            f'{self.__class__.__name__}('
+            f'status_code={self.status_code!r}, '
+            f'message={self.message!r}, '
+            f'detail={self.detail!r}, '
+            f'headers={self.headers!r}, '
+            f'extra_data={self.extra_data!r}'
+            f')'
+        )
+
 
 class _ValidationError(HTTPError):
     """The exception used when the request validation error happened."""

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -2,6 +2,7 @@ import pytest
 
 from apiflask.exceptions import abort
 from apiflask.exceptions import HTTPError
+from apiflask.helpers import get_reason_phrase
 
 
 @pytest.mark.parametrize(
@@ -141,3 +142,32 @@ def test_custom_error_classes(app, client):
     assert rv.json['error_code'] == '345'
     assert rv.json['error_docs'] == 'https://example.com/docs/gone'
     assert rv.json['detail'] == {}
+
+
+@pytest.mark.parametrize(
+    'kwargs',
+    [
+        {},
+        {'message': 'bad'},
+        {'message': 'bad', 'detail': {'location': 'json'}},
+        {'message': 'bad', 'detail': {'location': 'json'}, 'headers': {'X-FOO': 'bar'}},
+    ],
+)
+def test_httperror_str(kwargs):
+    http_error_msg = kwargs.get('message', None)
+
+    if http_error_msg is None:
+        http_error_msg = get_reason_phrase(400)
+
+    assert http_error_msg in str(HTTPError(400, **kwargs))
+
+
+def test_httperror_str_default_status_code():
+    assert get_reason_phrase(500) in str(HTTPError())
+
+
+def test_httperror_str_custom_error_class_message():
+    class PetDown(HTTPError):
+        message = 'The pet is down.'
+
+    assert 'The pet is down.' in str(PetDown())


### PR DESCRIPTION
Add __str__ to HTTPError to return a human-readable string representation, and add corresponding unit tests for the new method.

fixes #748 


Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [ ] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
