### PR TITLE
Release 3.1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Version: 3.1.1
 
-Released: -
+Released: 2026/6/19
 
 - Support flask-httpauth 4.8.1+ ([issue #743][issue_743]).
 - Add `__str__` method to `HTTPError` to return a human-readable string representation ([issue #748][issue_748]).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "A lightweight web API framework based on Flask."
 readme = "README.md"
 license = { text = "MIT" }
 authors = [{ name = "Grey Li", email = "withlihui@gmail.com" }]
-version = "3.1.0"
+version = "3.1.1"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",


### PR DESCRIPTION
- Support flask-httpauth 4.8.1+ #743.
- Add `__str__` method to `HTTPError` to return a human-readable string representation #748.
- Normalize header names in OpenAPI #750.