### PR TITLE
fix: recognize list[UploadFile] as a multiple file field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Version: Unreleased
+
+- Fix `list[UploadFile]` not being recognized as a multiple file field ([issue #755][issue_755]).
+
+[issue_755]: https://github.com/apiflask/apiflask/issues/755
+
 ## Version: 3.1.1
 
 Released: 2026/6/19

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
-## Version: Unreleased
+## Version: 3.1.2
+
+Released: -
 
 - Fix `list[UploadFile]` not being recognized as a multiple file field ([issue #755][issue_755]).
 

--- a/src/apiflask/helpers.py
+++ b/src/apiflask/helpers.py
@@ -167,6 +167,22 @@ def pagination_builder(
         raise ValueError('Invalid schema_type parameter, should be "marshmallow" or "pydantic"')
 
 
+def _is_same_type(left: t.Any, right: t.Any) -> bool:
+    """A helper function to compare two annotations.
+
+    Generic aliases are compared by their origin and arguments, so that the
+    equivalent ``typing.List[X]`` and ``list[X]`` spellings match.
+    """
+    if left == right:
+        return True
+    origin = t.get_origin(left)
+    return (
+        origin is not None
+        and origin is t.get_origin(right)
+        and t.get_args(left) == t.get_args(right)
+    )
+
+
 def _get_fields_by_type(model_class: type[BaseModel], field_type: type) -> t.List[str]:
     """A helper function to get the fields of the specified type in BaseModel.
 
@@ -175,7 +191,8 @@ def _get_fields_by_type(model_class: type[BaseModel], field_type: type) -> t.Lis
     return [
         field_name
         for field_name, field in model_class.__pydantic_fields__.items()
-        if field_type == field.annotation or field_type in t.get_args(field.annotation)
+        if _is_same_type(field_type, field.annotation)
+        or any(_is_same_type(field_type, arg) for arg in t.get_args(field.annotation))
     ]
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -239,6 +239,34 @@ def test_multiple_file_model(app, client):
     assert rv.json == {'images': True}
 
 
+def test_multiple_file_model_with_builtin_list(app, client):
+    # the PEP 585 list[UploadFile] spelling must behave like t.List[UploadFile]
+    class Files(BaseModel):
+        images: list[UploadFile]
+
+    @app.post('/')
+    @app.input(Files, location='files')
+    def index(files_data: Files):
+        data = {'images': True, 'count': len(files_data.images)}
+        for f in files_data.images:
+            if not isinstance(f, FileStorage):
+                data['images'] = False
+        return data
+
+    rv = client.post(
+        '/',
+        data={
+            'images': [
+                (io.BytesIO(b'test0'), 'test0.jpg'),
+                (io.BytesIO(b'test1'), 'test1.jpg'),
+            ]
+        },
+        content_type='multipart/form-data',
+    )
+    assert rv.status_code == 200
+    assert rv.json == {'images': True, 'count': 2}
+
+
 def test_empty_file_model(app, client):
     class Files(BaseModel):
         image: t.Optional[UploadFile] = None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -150,6 +150,25 @@ def test_get_fields_by_type():
     assert _get_fields_by_type(optional_files, t.List[UploadFile]) == ['file_list']
 
 
+def test_get_fields_by_type_with_builtin_generics():
+    # list[UploadFile] and t.List[UploadFile] are equivalent annotations
+    class Files(BaseModel):
+        single_file: UploadFile
+        file_list: list[UploadFile]
+
+    class OptionalFiles(BaseModel):
+        file_list: t.Optional[list[UploadFile]] = None
+
+    fs = FileStorage(io.BytesIO(b'test'), 'test.jpg')
+    fs_list = [FileStorage(io.BytesIO(b'test'), 'test1.jpg')]
+
+    files = Files(single_file=fs, file_list=fs_list)
+    assert _get_fields_by_type(files, t.List[UploadFile]) == ['file_list']
+    assert _get_fields_by_type(files, list[UploadFile]) == ['file_list']
+
+    assert _get_fields_by_type(OptionalFiles(), t.List[UploadFile]) == ['file_list']
+
+
 def test_normalize_header_name():
     assert _normalize_header_name('') == ''
     assert _normalize_header_name('x_token') == 'x-token'


### PR DESCRIPTION
`_get_fields_by_type` compares annotations with `==`, but `typing.List[X] == list[X]` is `False` even though both describe the same type (their `get_origin` and `get_args` are identical).

So for a field annotated `list[UploadFile]`:

- the `List[UploadFile]` lookup returns `[]`, so the field is never collected as a file **list**
- the plain `UploadFile` lookup still matches it (because `UploadFile` is in its `get_args`), so it is treated as a **single** file

`handle_files()` then reads it with `request.files.get()` instead of `request.files.getlist()`, and pydantic rejects the value — uploading multiple files returns 422 `"Not a valid file."` instead of 200. `t.Optional[list[UploadFile]]` is affected identically.

This adds a small `_is_same_type()` helper that compares generic aliases by their origin and arguments, and uses it for both the direct comparison and the `get_args` membership test. Bare types such as `UploadFile` and `FileStorage` have no origin, so they still fall back to `==` and existing behaviour is unchanged.

fixes #755

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue.
- [ ] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.

Notes on the unchecked items:

- No docs change: `list[UploadFile]` was already the documented, expected way to declare a multiple file field — this only makes it work.
- No `*Version changed*` note: the behaviour of `_get_fields_by_type` is unchanged for every annotation that already worked, so there is nothing to flag for users.
- I put the `CHANGES.md` entry under a `Version: Unreleased` heading rather than guessing the next version number — happy to retitle it to whatever you plan to release as.

Tests added:

- `tests/test_fields.py::test_multiple_file_model_with_builtin_list` — mirrors the existing `test_multiple_file_model` but with `list[UploadFile]`; posts two files and asserts a 200 with both received.
- `tests/test_helpers.py::test_get_fields_by_type_with_builtin_generics` — covers `list[UploadFile]` and `t.Optional[list[UploadFile]]` at the helper level.

Both fail on `main` and pass with the change. `pytest` gives 397 passed; the single failure, `tests/test_openapi_headers.py::test_spec_with_dict_headers`, also fails on a clean checkout here and is unrelated to this change. `ruff check` and `ruff format --check` are clean.
