### PR TITLE
Register nested Pydantic schemas used in parameter locations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,11 @@ Released: -
 
 - Fix `list[UploadFile]` not being recognized as a multiple file field ([issue #755][issue_755]).
 - Fix AUTO_200_RESPONSE sharing the same mutable empty schema object across endpoints ([issue #758][issue_758]).
+- Fix nested Pydantic schemas (e.g. enums) not being registered in `components/schemas` when the model is used in a parameter location such as `query`, `headers`, or `cookies` ([issue #757][issue_757]).
 
 [issue_755]: https://github.com/apiflask/apiflask/issues/755
 [issue_758]: https://github.com/apiflask/apiflask/issues/758
+[issue_757]: https://github.com/apiflask/apiflask/issues/757
 
 ## Version: 3.1.1
 

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -983,7 +983,7 @@ class APIFlask(APIScaffold, Flask):
                     try:
                         # Use schema_to_parameters for proper handling of different schema types
                         schema_params = openapi_helper.schema_to_parameters(
-                            schema, location=location
+                            schema, location=location, spec=spec
                         )
                         parameters.extend(schema_params)
                     except Exception:
@@ -1468,7 +1468,9 @@ class APIFlask(APIScaffold, Flask):
             operation['responses'][status_code]['links'] = links
         if headers_schema is not None:
             # Use openapi_helper to convert headers schema to parameters
-            header_params = openapi_helper.schema_to_parameters(headers_schema, location='headers')
+            header_params = openapi_helper.schema_to_parameters(
+                headers_schema, location='headers', spec=spec
+            )
             headers = {header['name']: header for header in header_params}
             for header in headers.values():
                 header.pop('in', None)

--- a/src/apiflask/openapi_adapters.py
+++ b/src/apiflask/openapi_adapters.py
@@ -190,7 +190,10 @@ class OpenAPIHelper:
             # the property schemas at `#/components/schemas/{parent}.{model}`.
             # Register them so those references resolve, the same way body
             # schemas are handled in `APIFlask._register_schema_and_get_ref`.
-            if spec is not None:
+            # This is limited to Pydantic because the `{parent}.{model}` naming
+            # comes from the ref template in `PydanticAdapter.get_openapi_schema`,
+            # so it would not match the refs emitted by any other adapter.
+            if spec is not None and adapter.schema_type == 'pydantic':
                 nested_defs = extract_pydantic_defs(schema_spec, adapter.get_schema_name())
                 for nested_name, nested_schema in nested_defs.items():
                     if nested_name not in spec.components.schemas:

--- a/src/apiflask/openapi_adapters.py
+++ b/src/apiflask/openapi_adapters.py
@@ -193,7 +193,7 @@ class OpenAPIHelper:
             # This is limited to Pydantic because the `{parent}.{model}` naming
             # comes from the ref template in `PydanticAdapter.get_openapi_schema`,
             # so it would not match the refs emitted by any other adapter.
-            if spec is not None and adapter.schema_type == 'pydantic':
+            if adapter.schema_type == 'pydantic' and spec is not None:
                 nested_defs = extract_pydantic_defs(schema_spec, adapter.get_schema_name())
                 for nested_name, nested_schema in nested_defs.items():
                     if nested_name not in spec.components.schemas:

--- a/src/apiflask/openapi_adapters.py
+++ b/src/apiflask/openapi_adapters.py
@@ -138,16 +138,24 @@ class OpenAPIHelper:
             return {'type': 'object'}
 
     def schema_to_parameters(
-        self, schema: t.Any, location: str = 'query'
+        self, schema: t.Any, location: str = 'query', spec: APISpec | None = None
     ) -> list[dict[str, t.Any]]:
         """Convert schema to OpenAPI parameters.
 
         Arguments:
             schema: Schema object
             location: Parameter location ('query', 'header', etc.)
+            spec: The APISpec object used to register nested schemas
+                referenced by the parameters (e.g. Pydantic enums). When
+                omitted, nested schemas are not registered.
 
         Returns:
             List of OpenAPI parameter definitions
+
+        *Version changed: 3.1.2*
+
+        - Add parameter `spec` to register nested schemas referenced by
+          the generated parameters.
         """
         try:
             adapter = registry.create_adapter(schema)
@@ -177,6 +185,17 @@ class OpenAPIHelper:
 
             # For other schema types, generate basic parameters
             schema_spec = adapter.get_openapi_schema()
+
+            # Pydantic emits nested models (e.g. enums) into `$defs` and points
+            # the property schemas at `#/components/schemas/{parent}.{model}`.
+            # Register them so those references resolve, the same way body
+            # schemas are handled in `APIFlask._register_schema_and_get_ref`.
+            if spec is not None:
+                nested_defs = extract_pydantic_defs(schema_spec, adapter.get_schema_name())
+                for nested_name, nested_schema in nested_defs.items():
+                    if nested_name not in spec.components.schemas:
+                        spec.components.schema(nested_name, nested_schema)
+
             parameters = []
 
             if 'properties' in schema_spec:

--- a/tests/test_pydantic_integration.py
+++ b/tests/test_pydantic_integration.py
@@ -1,4 +1,6 @@
 import sys
+import typing
+from enum import Enum
 
 import openapi_spec_validator as osv
 import pytest
@@ -601,3 +603,95 @@ class TestPydanticIntegration:
             assert isinstance(data, dict)
             assert data['user_id'] == 1
             assert data['username'] == 'John Doe'
+
+    @pytest.mark.parametrize(
+        'location, expected_in',
+        [('query', 'query'), ('headers', 'header'), ('cookies', 'cookie')],
+    )
+    def test_enum_in_parameters_registers_nested_schema(self, location, expected_in):
+        """Test that enums used in parameter locations are registered in components/schemas."""
+
+        class PetCategory(str, Enum):
+            DOG = 'dog'
+            CAT = 'cat'
+
+        class PetQuery(BaseModel):
+            category: PetCategory
+
+        app = APIFlask(__name__)
+
+        @app.get('/pets')
+        @app.input(PetQuery, location=location)
+        def get_pets(**kwargs):
+            return []
+
+        with app.test_client() as client:
+            rv = client.get('/openapi.json')
+            assert rv.status_code == 200
+            osv.validate(rv.json)
+
+            spec = rv.get_json()
+            schemas = spec['components']['schemas']
+
+            # The nested enum must be registered, not just referenced
+            assert 'PetQuery.PetCategory' in schemas
+            assert schemas['PetQuery.PetCategory']['enum'] == ['dog', 'cat']
+
+            parameter = spec['paths']['/pets']['get']['parameters'][0]
+            assert parameter['name'] == 'category'
+            assert parameter['in'] == expected_in
+            assert parameter['schema']['$ref'] == '#/components/schemas/PetQuery.PetCategory'
+
+    def test_enum_in_parameters_leaves_no_dangling_refs(self):
+        """Test that a spec mixing body and parameter enums resolves every $ref."""
+
+        class PetCategory(str, Enum):
+            DOG = 'dog'
+            CAT = 'cat'
+
+        class PetQuery(BaseModel):
+            category: typing.Optional[PetCategory] = None
+
+        class PetIn(BaseModel):
+            name: str
+            category: PetCategory
+
+        app = APIFlask(__name__)
+
+        @app.get('/pets')
+        @app.input(PetQuery, location='query')
+        def get_pets(query_data):
+            return []
+
+        @app.post('/pets')
+        @app.input(PetIn, location='json')
+        def create_pet(json_data):
+            return {}
+
+        with app.test_client() as client:
+            rv = client.get('/openapi.json')
+            assert rv.status_code == 200
+            osv.validate(rv.json)
+
+            spec = rv.get_json()
+            defined = {f'#/components/schemas/{name}' for name in spec['components']['schemas']}
+
+            refs = []
+
+            def collect_refs(node):
+                if isinstance(node, dict):
+                    for key, value in node.items():
+                        if key == '$ref':
+                            refs.append(value)
+                        else:
+                            collect_refs(value)
+                elif isinstance(node, list):
+                    for item in node:
+                        collect_refs(item)
+
+            collect_refs(spec)
+
+            assert refs  # guard against the walk silently finding nothing
+            assert sorted(set(refs) - defined) == []
+            assert 'PetQuery.PetCategory' in spec['components']['schemas']
+            assert 'PetIn.PetCategory' in spec['components']['schemas']


### PR DESCRIPTION
Closes #757

### What was happening

Pydantic puts nested definitions like enums into `$defs` and points the property schemas at `#/components/schemas/{parent}.{model}`.

For request bodies that works, because `APIFlask._register_schema_and_get_ref` pulls those definitions out and registers them. For parameter locations it did not. `schema_to_parameters` built the parameters straight from `properties` and discarded `$defs`, so the emitted `$ref` pointed at a schema that was never added to the document.

Using the example from the issue, `PetQuery.PetCategory` was referenced but never defined:

```json
{
  "in": "query",
  "name": "category",
  "schema": {"anyOf": [{"$ref": "#/components/schemas/PetQuery.PetCategory"}, {"type": "null"}]}
}
```

while `components/schemas` only held `PetIn`, `PetIn.PetCategory`, `PetOut`, `PetOut.PetCategory` and `ValidationError`.

This is not only a docs rendering problem. The spec is genuinely invalid, and `openapi_spec_validator` rejects it with `PointerToNowhere`.

### The change

`schema_to_parameters` now takes the `APISpec` and registers the nested definitions itself, reusing the existing `extract_pydantic_defs` helper so parameters and bodies resolve names the same way. Both call sites in `app.py` pass it through, one for operation parameters and one for response headers.

The new argument is optional and defaults to `None`, so calling `schema_to_parameters` without a spec keeps the old behaviour and nothing outside APIFlask breaks.

I went with registering the schema rather than inlining the enum values, since the issue lists that as the expected behaviour and it matches what already happens for `location="json"`.

### Tests

Added to `tests/test_pydantic_integration.py`:

* a parametrised test covering `query`, `headers` and `cookies`, asserting the enum lands in `components/schemas` and the parameter references it
* a test that builds a spec mixing a body model and a query model, walks every `$ref` in the document and asserts none of them dangle

Both fail on `main` and pass with this change. The full suite is green, 406 passed and 1 skipped, and `ruff`, `ruff format` and `mypy` are clean.
