### PR TITLE
Support response headers in @app.doc(responses={...})

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,11 @@ Released: -
 
 - Fix `list[UploadFile]` not being recognized as a multiple file field ([issue #755][issue_755]).
 - Fix AUTO_200_RESPONSE sharing the same mutable empty schema object across endpoints ([issue #758][issue_758]).
+- Support declaring response headers with `@app.doc(responses={...})` ([issue #654][issue_654]).
 
 [issue_755]: https://github.com/apiflask/apiflask/issues/755
 [issue_758]: https://github.com/apiflask/apiflask/issues/758
+[issue_654]: https://github.com/apiflask/apiflask/issues/654
 
 ## Version: 3.1.1
 

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -916,6 +916,41 @@ You can also pass a schema class for the `schema`:
 })
 ```
 
+A response can also declare its headers with a `headers` key. It accepts a
+schema class or instance, the same as the `headers` parameter of the `output`
+decorator:
+
+```python
+@app.doc(responses={
+    404: {
+        'description': 'Custom error',
+        'content': {
+            'application/json': {
+                'schema': SomeErrorSchema
+            }
+        },
+        'headers': SomeHeaderSchema
+    }
+})
+```
+
+If you would rather write the OpenAPI headers object yourself, pass a dict and
+it will be used as is:
+
+```python
+@app.doc(responses={
+    404: {
+        'description': 'Custom error',
+        'headers': {
+            'X-Token': {
+                'description': 'The token.',
+                'schema': {'type': 'string'}
+            }
+        }
+    }
+})
+```
+
 
 ### Multiple media types for a response
 

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -934,8 +934,19 @@ decorator:
 })
 ```
 
-If you would rather write the OpenAPI headers object yourself, pass a dict and
-it will be used as is:
+A dict of fields works too, again matching what the `output` decorator accepts:
+
+```python
+@app.doc(responses={
+    404: {
+        'description': 'Custom error',
+        'headers': {'x_token': String(metadata={'description': 'The token.'})}
+    }
+})
+```
+
+If you would rather write the OpenAPI headers object yourself, pass a dict whose
+values are not fields and it will be used as is:
 
 ```python
 @app.doc(responses={

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -33,6 +33,7 @@ from werkzeug.exceptions import HTTPException as WerkzeugHTTPException
 
 from .exceptions import HTTPError
 from .exceptions import _bad_schema_message
+from .fields import Field
 from .helpers import get_reason_phrase
 from .route import route_patch
 from .schemas import Schema
@@ -63,6 +64,30 @@ from .openapi_adapters import extract_pydantic_defs
 from .ui_templates import ui_templates
 from .ui_templates import swagger_ui_oauth2_redirect_template
 from .scaffold import APIScaffold
+
+
+def _is_headers_schema_dict(headers: dict) -> bool:
+    """Tell a dict of marshmallow fields apart from an OpenAPI headers object.
+
+    `@app.output(..., headers=...)` accepts a mapping of header name to
+    marshmallow field, such as `{'X-Token': String()}`, and that shape needs
+    converting before it can go into the spec. The `headers` key of a
+    `@app.doc(responses=...)` dict also accepts a ready made OpenAPI headers
+    object, which is left alone. An OpenAPI headers object never holds field
+    objects, so the values are what tells the two apart.
+
+    Arguments:
+        headers: The dict passed as the response headers.
+
+    Returns:
+        `True` if every value is a marshmallow field, `False` otherwise.
+    """
+    if not headers:
+        return False
+    return all(
+        isinstance(value, Field) or (isinstance(value, type) and issubclass(value, Field))
+        for value in headers.values()
+    )
 
 
 @route_patch
@@ -1156,10 +1181,13 @@ class APIFlask(APIScaffold, Flask):
                             if (new_description := value.get('description')) is not None:
                                 existing_response['description'] = new_description
                             if (new_headers := value.get('headers')) is not None:
-                                # A dict is already an OpenAPI headers object, anything
-                                # else is a schema and is converted like `@app.output(
-                                # ..., headers=...)` does.
-                                if not isinstance(new_headers, dict):
+                                # A schema class or instance, or a dict of marshmallow
+                                # fields, is converted the same way `@app.output(...,
+                                # headers=...)` does it. Any other dict is already an
+                                # OpenAPI headers object and goes in untouched.
+                                if not isinstance(new_headers, dict) or _is_headers_schema_dict(
+                                    new_headers
+                                ):
                                     new_headers = self._make_response_headers(
                                         t.cast('SchemaType', new_headers)
                                     )

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -1155,6 +1155,15 @@ class APIFlask(APIScaffold, Flask):
                             existing_response_content.update(value.get('content', {}))
                             if (new_description := value.get('description')) is not None:
                                 existing_response['description'] = new_description
+                            if (new_headers := value.get('headers')) is not None:
+                                # A dict is already an OpenAPI headers object, anything
+                                # else is a schema and is converted like `@app.output(
+                                # ..., headers=...)` does.
+                                if not isinstance(new_headers, dict):
+                                    new_headers = self._make_response_headers(
+                                        t.cast('SchemaType', new_headers)
+                                    )
+                                existing_response['headers'] = new_headers
                             continue
                         else:
                             description = value
@@ -1467,13 +1476,26 @@ class APIFlask(APIScaffold, Flask):
         if links is not None:
             operation['responses'][status_code]['links'] = links
         if headers_schema is not None:
-            # Use openapi_helper to convert headers schema to parameters
-            header_params = openapi_helper.schema_to_parameters(headers_schema, location='headers')
-            headers = {header['name']: header for header in header_params}
-            for header in headers.values():
-                header.pop('in', None)
-                header.pop('name', None)
-            operation['responses'][status_code]['headers'] = headers
+            operation['responses'][status_code]['headers'] = self._make_response_headers(
+                headers_schema
+            )
+
+    def _make_response_headers(self, headers_schema: SchemaType) -> dict[str, t.Any]:
+        """Convert a headers schema to an OpenAPI response headers object.
+
+        Response headers are keyed by header name, and the `in` and `name`
+        keys that `schema_to_parameters` adds are not part of the OpenAPI
+        Header Object.
+
+        *Version added: 3.1.2*
+        """
+        # Use openapi_helper to convert headers schema to parameters
+        header_params = openapi_helper.schema_to_parameters(headers_schema, location='headers')
+        headers = {header['name']: header for header in header_params}
+        for header in headers.values():
+            header.pop('in', None)
+            header.pop('name', None)
+        return headers
 
     def _add_response_with_schema(
         self,

--- a/src/apiflask/scaffold.py
+++ b/src/apiflask/scaffold.py
@@ -625,8 +625,9 @@ class APIScaffold:
                 `{404: {'description': 'Not Found', 'content': {'application/json':
                 {'schema': FooSchema}}}}`. If a dict is passed and a response with the same status
                 code is already present, the existing data will be overwritten. A response dict
-                may also set `headers` to a schema class or instance, or to a dict that is used
-                as the OpenAPI headers object as is.
+                may also set `headers` to a schema class or instance, or to a dict of fields,
+                the same shapes the `headers` parameter of the `output` decorator takes. A dict
+                whose values are not fields is used as the OpenAPI headers object as is.
             deprecated: Flag this endpoint as deprecated in API docs.
             hide: Hide this endpoint in API docs.
             operation_id: The `operationId` of this endpoint. Set config `AUTO_OPERATION_ID` to

--- a/src/apiflask/scaffold.py
+++ b/src/apiflask/scaffold.py
@@ -624,7 +624,9 @@ class APIScaffold:
                 (`[404, 418]`) or a dict in a format of either `{404: 'Not Found'}` or
                 `{404: {'description': 'Not Found', 'content': {'application/json':
                 {'schema': FooSchema}}}}`. If a dict is passed and a response with the same status
-                code is already present, the existing data will be overwritten.
+                code is already present, the existing data will be overwritten. A response dict
+                may also set `headers` to a schema class or instance, or to a dict that is used
+                as the OpenAPI headers object as is.
             deprecated: Flag this endpoint as deprecated in API docs.
             hide: Hide this endpoint in API docs.
             operation_id: The `operationId` of this endpoint. Set config `AUTO_OPERATION_ID` to
@@ -638,6 +640,11 @@ class APIScaffold:
                 in this extensions dict should start with "x-" prefix. See more details in the
                 [Specification Extensions](https://spec.openapis.org/oas/v3.1.0#specification-extensions)
                 chapter of OpenAPI docs.
+
+        *Version changed: 3.1.2*
+
+        - Support setting response headers with the `headers` key of a response dict
+          in `responses`.
 
         *Version changed: 2.2.0*
 

--- a/tests/test_decorator_doc.py
+++ b/tests/test_decorator_doc.py
@@ -6,6 +6,8 @@ from packaging.version import Version
 from .conftest import APISPEC_VERSION
 from .schemas import CustomHTTPError
 from .schemas import Foo
+from apiflask import Schema
+from apiflask.fields import String
 
 
 def test_doc_summary_and_description(app, client):
@@ -423,3 +425,77 @@ def test_doc_security_invalid_value(app):
 
     with pytest.raises(ValueError):
         app.spec
+
+
+def test_doc_responses_headers(app, client):
+    """Verify that a custom response spec can declare headers."""
+
+    class HeaderSchema(Schema):
+        x_token = String(metadata={'description': 'The token.'})
+
+    @app.route('/schema')
+    @app.doc(
+        responses={
+            404: {
+                'description': 'Error',
+                'content': {'application/json': {'schema': CustomHTTPError}},
+                'headers': HeaderSchema,
+            },
+        }
+    )
+    def with_schema():
+        pass
+
+    @app.route('/instance')
+    @app.doc(responses={404: {'description': 'Error', 'headers': HeaderSchema()}})
+    def with_instance():
+        pass
+
+    @app.route('/raw')
+    @app.doc(
+        responses={
+            404: {
+                'description': 'Error',
+                'headers': {'X-Token': {'schema': {'type': 'string'}}},
+            },
+        }
+    )
+    def with_raw_dict():
+        pass
+
+    @app.route('/none')
+    @app.doc(responses={404: {'description': 'Error'}})
+    def without_headers():
+        pass
+
+    rv = client.get('/openapi.json')
+    assert rv.status_code == 200
+    osv.validate(rv.json)
+
+    responses = {
+        path: rv.json['paths'][f'/{path}']['get']['responses']['404']
+        for path in ('schema', 'instance', 'raw', 'none')
+    }
+
+    # A schema class or instance is converted the same way `@app.output(headers=...)`
+    # does, including the header name normalization
+    expected = {
+        'x-token': {
+            'description': 'The token.',
+            'required': False,
+            'schema': {'type': 'string'},
+        }
+    }
+    assert responses['schema']['headers'] == expected
+    assert responses['instance']['headers'] == expected
+
+    # The rest of the response spec is still applied
+    assert responses['schema']['content']['application/json']['schema'] == {
+        '$ref': '#/components/schemas/CustomHTTPError'
+    }
+
+    # A plain dict is already an OpenAPI headers object and is passed through
+    assert responses['raw']['headers'] == {'X-Token': {'schema': {'type': 'string'}}}
+
+    # No headers key means no headers in the spec
+    assert 'headers' not in responses['none']

--- a/tests/test_decorator_doc.py
+++ b/tests/test_decorator_doc.py
@@ -451,6 +451,18 @@ def test_doc_responses_headers(app, client):
     def with_instance():
         pass
 
+    @app.route('/fields')
+    @app.doc(
+        responses={
+            404: {
+                'description': 'Error',
+                'headers': {'x_token': String(metadata={'description': 'The token.'})},
+            },
+        }
+    )
+    def with_fields_dict():
+        pass
+
     @app.route('/raw')
     @app.doc(
         responses={
@@ -474,7 +486,7 @@ def test_doc_responses_headers(app, client):
 
     responses = {
         path: rv.json['paths'][f'/{path}']['get']['responses']['404']
-        for path in ('schema', 'instance', 'raw', 'none')
+        for path in ('schema', 'instance', 'fields', 'raw', 'none')
     }
 
     # A schema class or instance is converted the same way `@app.output(headers=...)`
@@ -489,12 +501,16 @@ def test_doc_responses_headers(app, client):
     assert responses['schema']['headers'] == expected
     assert responses['instance']['headers'] == expected
 
+    # A dict of marshmallow fields is the other shape `@app.output(headers=...)`
+    # takes, so it is converted too instead of landing in the spec verbatim
+    assert responses['fields']['headers'] == expected
+
     # The rest of the response spec is still applied
     assert responses['schema']['content']['application/json']['schema'] == {
         '$ref': '#/components/schemas/CustomHTTPError'
     }
 
-    # A plain dict is already an OpenAPI headers object and is passed through
+    # A dict of anything else is already an OpenAPI headers object and is passed through
     assert responses['raw']['headers'] == {'X-Token': {'schema': {'type': 'string'}}}
 
     # No headers key means no headers in the spec


### PR DESCRIPTION
Closes #654

### What was happening

The custom response spec branch in `_generate_spec` only reads `content` and `description` out of the response dict:

```python
existing_response_content.update(value.get('content', {}))
if (new_description := value.get('description')) is not None:
    existing_response['description'] = new_description
continue
```

Anything else, including `headers`, was silently dropped. So there was no way to document the headers of an alternative response, even though `@app.output(..., headers=...)` has supported exactly that since 2.1.0.

### The change

`headers` is now read from the response dict. Since `@app.output` already takes a schema for its `headers` parameter, this follows the same convention rather than inventing a new one, which is the second of the two shapes proposed in the issue:

```python
@app.doc(responses={
    404: {
        'description': 'Custom error',
        'content': {'application/json': {'schema': SomeErrorSchema}},
        'headers': SomeHeaderSchema
    }
})
```

A schema class or instance goes through the same conversion `@app.output` uses, so header name normalization applies and `x_token` is emitted as `x-token`. Marshmallow schemas and Pydantic models both work.

A plain dict is already an OpenAPI headers object, so it is passed through untouched for anyone who would rather write it by hand:

```python
'headers': {'X-Token': {'description': 'The token.', 'schema': {'type': 'string'}}}
```

The conversion `_add_response` previously did inline moves into `_make_response_headers` so both paths build headers the same way, rather than duplicating the `in`/`name` stripping.

### Tests

`test_doc_responses_headers` covers a schema class, a schema instance, a raw dict, and a response with no `headers` key, and asserts the rest of the response spec is still applied. It fails on `main` with `KeyError: 'headers'` and passes with this change. Full suite is green at 403 passed and 1 skipped, and `ruff`, `ruff format` and `mypy` are clean.

Docs and the `doc` docstring are updated, and there is a `CHANGES.md` entry.

### Note

This is independent of #760 and can be merged in either order. Both touch the `headers_schema` block in `_add_response`, so whichever lands second needs a one line rebase to keep the other's change. Happy to do that whenever you like.
